### PR TITLE
Add missing babel dependency & prepack step

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "rosbag",
-  "version": "1.3.2",
-  "private": true,
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "3.5.0",
@@ -15,6 +14,7 @@
   "main": "es5",
   "module": "lib",
   "scripts": {
+    "prepack": "npm run build",
     "lint": "eslint lib test",
     "lint-prettier": "prettier -l '{lib,test}/**/*.js'",
     "mocha": "mocha test/*.js",
@@ -26,6 +26,7 @@
     "babel-cli": "6.24.0",
     "babel-core": "6.24.0",
     "babel-eslint": "7.2.1",
+    "babel-plugin-syntax-async-functions": "6.13.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.24.0",
     "babel-register": "6.24.0",
     "chai": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,6 +270,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-syntax-async-functions@6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
 babel-plugin-transform-es2015-modules-commonjs@6.24.0:
   version "6.24.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.0.tgz#e921aefb72c2cc26cb03d107626156413222134f"


### PR DESCRIPTION
Added back a missing dev dependency for babel, and set up a `prepack` step to compile the es5 code before publishing to npm. 

Set version to `0.9.0` in package.json so when I run `npm version major -m 'Bump version' && npm publish` locally we'll push out the compiled sources to npm with `rosbag@1.0.0` which will be the first npm release.