### PR TITLE
Increment reader offset after reading arrays

### DIFF
--- a/lib/MessageReader.js
+++ b/lib/MessageReader.js
@@ -55,7 +55,7 @@ class StandardTypeReader {
   typedArray(len, ArrayType) {
     const arrayLength = len || this.uint32();
     const data = new ArrayType(this.view.buffer, this.offset + this.view.byteOffset, arrayLength);
-    this.offset += arrayLength;
+    this.offset += arrayLength * ArrayType.BYTES_PER_ELEMENT;
 
     return data;
   }

--- a/lib/MessageReader.js
+++ b/lib/MessageReader.js
@@ -264,14 +264,16 @@ Record.${friendlyName(t.name)} = function() {
 
         if (def.type === "uint8") {
           readerLines.push(
-            `${arrayName} = new Uint8Array(reader.buffer.buffer, reader.offset + reader.buffer.byteOffset, ${lenField});`
+            `${arrayName} = new Uint8Array(reader.buffer.buffer, reader.offset + reader.buffer.byteOffset, ${lenField});`,
+            `reader.offset += ${lenField};`
           );
           return;
         }
 
         if (def.type === "int8") {
           readerLines.push(
-            `${arrayName} = new Int8Array(reader.buffer.buffer, reader.offset + reader.buffer.byteOffset, ${lenField});`
+            `${arrayName} = new Int8Array(reader.buffer.buffer, reader.offset + reader.buffer.byteOffset, ${lenField});`,
+            `reader.offset += ${lenField};`
           );
           return;
         }

--- a/lib/MessageReader.js
+++ b/lib/MessageReader.js
@@ -55,7 +55,7 @@ class StandardTypeReader {
   typedArray(len, ArrayType) {
     const arrayLength = len || this.uint32();
     const data = new ArrayType(this.view.buffer, this.offset + this.view.byteOffset, arrayLength);
-    this.offset += arrayLength * ArrayType.BYTES_PER_ELEMENT;
+    this.offset += arrayLength;
 
     return data;
   }

--- a/lib/MessageReader.js
+++ b/lib/MessageReader.js
@@ -52,6 +52,14 @@ class StandardTypeReader {
     return this.view.getUint8(this.offset++);
   }
 
+  typedArray(len, ArrayType) {
+    const arrayLength = len || this.uint32();
+    const data = new ArrayType(this.view.buffer, this.offset + this.view.byteOffset, arrayLength);
+    this.offset += arrayLength;
+
+    return data;
+  }
+
   int16() {
     const result = this.view.getInt16(this.offset, true);
     this.offset += 2;
@@ -243,6 +251,17 @@ Record.${friendlyName(t.name)} = function() {
     }
     type.definitions.forEach((def) => {
       if (def.isArray) {
+        if (def.type === "uint8" || def.type === "int8") {
+          let arrayType;
+          if (def.type === "uint8") {
+            arrayType = "Uint8Array";
+          } else if (def.type === "int8") {
+            arrayType = "Int8Array";
+          }
+
+          readerLines.push(`${fieldName}.${def.name} = reader.typedArray(${def.arrayLength}, ${arrayType});`);
+          return;
+        }
         // because we might have nested arrays
         // we need to incrementally number varaibles so they aren't
         // stomped on by other variables in the function
@@ -261,22 +280,6 @@ Record.${friendlyName(t.name)} = function() {
 
         // only allocate an array if there is a length - skips empty allocations
         const arrayName = `${fieldName}.${def.name}`;
-
-        if (def.type === "uint8") {
-          readerLines.push(
-            `${arrayName} = new Uint8Array(reader.buffer.buffer, reader.offset + reader.buffer.byteOffset, ${lenField});`,
-            `reader.offset += ${lenField};`
-          );
-          return;
-        }
-
-        if (def.type === "int8") {
-          readerLines.push(
-            `${arrayName} = new Int8Array(reader.buffer.buffer, reader.offset + reader.buffer.byteOffset, ${lenField});`,
-            `reader.offset += ${lenField};`
-          );
-          return;
-        }
 
         // allocate the new array to a fixed length since we know it ahead of time
         readerLines.push(`${arrayName} = new Array(${lenField})`);

--- a/test/MessageReader.js
+++ b/test/MessageReader.js
@@ -142,6 +142,23 @@ describe("MessageReader", () => {
         expect(values.buffer.byteLength).to.be.greaterThan(3);
       });
 
+      it("parses uint8[] with a fixed length", () => {
+        const reader = buildReader("uint8[3] values\nuint8 after");
+        const buffer = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+        const result = reader.readMessage(buffer);
+        const { values, after } = result;
+        expect(values instanceof Uint8Array).to.equal(true);
+        expect(values.buffer).to.equal(buffer.buffer);
+        expect(values.length).to.equal(3);
+        expect(values[0]).to.equal(1);
+        expect(values[1]).to.equal(2);
+        expect(values[2]).to.equal(3);
+
+        // Ensure the next value after the array gets read properly
+        expect(after).to.equal(4);
+        expect(values.buffer.byteLength).to.be.greaterThan(3);
+      });
+
       it("int8[] uses the same backing buffer", () => {
         const reader = buildReader("int8[] values\nint8 after");
         const buffer = new Buffer([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]);
@@ -157,6 +174,42 @@ describe("MessageReader", () => {
         // Ensure the next value after the array gets read properly
         expect(after).to.equal(4);
         expect(values.buffer.byteLength).to.be.greaterThan(3);
+      });
+
+      it("parses int8[] with a fixed length", () => {
+        const reader = buildReader("int8[3] values\nint8 after");
+        const buffer = new Buffer([0x01, 0x02, 0x03, 0x04]);
+        const result = reader.readMessage(buffer);
+        const { values, after } = result;
+        expect(values instanceof Int8Array).to.equal(true);
+        expect(values.buffer).to.equal(buffer.buffer);
+        expect(values.length).to.equal(3);
+        expect(values[0]).to.equal(1);
+        expect(values[1]).to.equal(2);
+        expect(values[2]).to.equal(3);
+
+        // Ensure the next value after the array gets read properly
+        expect(after).to.equal(4);
+        expect(values.buffer.byteLength).to.be.greaterThan(3);
+      });
+
+      it("parses combinations of typed arrays", () => {
+        const reader = buildReader("int8[] first\nuint8[2] second");
+        const buffer = new Buffer([0x02, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]);
+        const result = reader.readMessage(buffer);
+        const { first, second } = result;
+
+        expect(first instanceof Int8Array).to.equal(true);
+        expect(first.buffer).to.equal(buffer.buffer);
+        expect(first.length).to.equal(2);
+        expect(first[0]).to.equal(1);
+        expect(first[1]).to.equal(2);
+
+        expect(second instanceof Uint8Array).to.equal(true);
+        expect(second.buffer).to.equal(buffer.buffer);
+        expect(second.length).to.equal(2);
+        expect(second[0]).to.equal(3);
+        expect(second[1]).to.equal(4);
       });
     });
   });

--- a/test/MessageReader.js
+++ b/test/MessageReader.js
@@ -126,30 +126,36 @@ describe("MessageReader", () => {
 
     describe("typed arrays", () => {
       it("uint8[] uses the same backing buffer", () => {
-        const reader = buildReader("uint8[] values");
-        const buffer = Buffer.from([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03]);
+        const reader = buildReader("uint8[] values\nuint8 after");
+        const buffer = Buffer.from([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]);
         const result = reader.readMessage(buffer);
-        const { values } = result;
+        const { values, after } = result;
         expect(values instanceof Uint8Array).to.equal(true);
         expect(values.buffer).to.equal(buffer.buffer);
         expect(values.length).to.equal(3);
         expect(values[0]).to.equal(1);
         expect(values[1]).to.equal(2);
         expect(values[2]).to.equal(3);
+
+        // Ensure the next value after the array gets read properly
+        expect(after).to.equal(4);
         expect(values.buffer.byteLength).to.be.greaterThan(3);
       });
 
       it("int8[] uses the same backing buffer", () => {
-        const reader = buildReader("int8[] values");
-        const buffer = new Buffer([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03]);
+        const reader = buildReader("int8[] values\nint8 after");
+        const buffer = new Buffer([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]);
         const result = reader.readMessage(buffer);
-        const { values } = result;
+        const { values, after } = result;
         expect(values instanceof Int8Array).to.equal(true);
         expect(values.buffer).to.equal(buffer.buffer);
         expect(values.length).to.equal(3);
         expect(values[0]).to.equal(1);
         expect(values[1]).to.equal(2);
         expect(values[2]).to.equal(3);
+
+        // Ensure the next value after the array gets read properly
+        expect(after).to.equal(4);
         expect(values.buffer.byteLength).to.be.greaterThan(3);
       });
     });


### PR DESCRIPTION
Previously, when reading a typed array, we would not advance the offset of the reader, causing subsequent values to be filled incorrectly. This advances the offset so that this no longer happens.