### PR TITLE
Remove bluebird

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -48,7 +48,7 @@ rules:
   no-param-reassign: [error, {props: false}]
   no-tabs: error
   no-trailing-spaces: error
-  no-unused-vars: [error, {args: none}]
+  no-unused-vars: [error]
   no-var: error
   prefer-const: error
   quotes: [error, double]

--- a/lib/BagReader.js
+++ b/lib/BagReader.js
@@ -94,7 +94,7 @@ export default class BagReader {
   }
 
   // promisified version of readConnectionsAndChunkInfo
-  readConnectionsAndChunkInfoAsync(fileOffset, connectionCount, chunkCount, callback) {
+  readConnectionsAndChunkInfoAsync(fileOffset, connectionCount, chunkCount) {
     return new Promise((resolve, reject) => {
       this.readConnectionsAndChunkInfo(
         fileOffset,
@@ -160,7 +160,7 @@ export default class BagReader {
   }
 
   // promisified version of readChunkMessages
-  readChunkMessagesAsync(chunkInfo, connections, startTime, endTime, decompress, each, callback) {
+  readChunkMessagesAsync(chunkInfo, connections, startTime, endTime, decompress, each) {
     return new Promise((resolve, reject) => {
       this.readChunkMessages(
         chunkInfo,

--- a/lib/BagReader.js
+++ b/lib/BagReader.js
@@ -58,6 +58,11 @@ export default class BagReader {
     });
   }
 
+  // promisified version of readHeader
+  readHeaderAsync() {
+    return new Promise((resolve, reject) => this.readHeader((err, header) => (err ? reject(err) : resolve(header))));
+  }
+
   // reads connection and chunk information from the bag
   // you'll generally call this after reading the header so you can get connection metadata
   // and chunkInfos which allow you to seek to individual chunks & read them
@@ -85,6 +90,18 @@ export default class BagReader {
       }
 
       return callback(null, { connections, chunkInfos });
+    });
+  }
+
+  // promisified version of readConnectionsAndChunkInfo
+  readConnectionsAndChunkInfoAsync(fileOffset, connectionCount, chunkCount, callback) {
+    return new Promise((resolve, reject) => {
+      this.readConnectionsAndChunkInfo(
+        fileOffset,
+        connectionCount,
+        chunkCount,
+        (err, result) => (err ? reject(err) : resolve(result))
+      );
     });
   }
 
@@ -139,6 +156,21 @@ export default class BagReader {
       });
 
       return callback(null, messages);
+    });
+  }
+
+  // promisified version of readChunkMessages
+  readChunkMessagesAsync(chunkInfo, connections, startTime, endTime, decompress, each, callback) {
+    return new Promise((resolve, reject) => {
+      this.readChunkMessages(
+        chunkInfo,
+        connections,
+        startTime,
+        endTime,
+        decompress,
+        each,
+        (err, messages) => (err ? reject(err) : resolve(messages))
+      );
     });
   }
 

--- a/lib/bag.js
+++ b/lib/bag.js
@@ -4,8 +4,6 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import { promisifyAll } from "bluebird";
-
 import BagReader from "./BagReader";
 import MessageReader from "./MessageReader";
 import ReadResult from "./ReadResult";
@@ -23,7 +21,7 @@ import Time from "./Time";
 export default class Bag {
   // you can optionally create a bag manually passing in a bagReader instance
   constructor(bagReader) {
-    this.reader = promisifyAll(bagReader);
+    this.reader = bagReader;
   }
 
   // creates, opens, and returns a new bag reading

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.2",
   "license": "Apache-2.0",
   "dependencies": {
-    "bluebird": "3.5.0",
     "buffer": "5.0.5",
     "heap": "0.2.6",
     "int53": "0.2.4"

--- a/test/Reader.js
+++ b/test/Reader.js
@@ -4,7 +4,6 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import { promisify } from "bluebird";
 import path from "path";
 import assert from "assert";
 
@@ -13,13 +12,13 @@ import Reader from "../lib/readers/node";
 describe("Reader", () => {
   const fixture = path.join(__dirname, "fixtures", "asci-file.txt");
 
-  it("should read bytes from a file", async () => {
+  it("should read bytes from a file", (done) => {
     const reader = new Reader(fixture);
-
-    const buff = await promisify(reader.read.bind(reader))(5, 10);
-    assert.equal(reader.size(), 21);
-    assert.equal("6789012345", buff.toString());
-
-    await promisify(reader.close.bind(reader))();
+    reader.read(5, 10, (err, buff) => {
+      assert(!err);
+      assert.equal(reader.size(), 21);
+      assert.equal("6789012345", buff.toString());
+      reader.close(done);
+    });
   });
 });

--- a/test/browser-reader.js
+++ b/test/browser-reader.js
@@ -24,8 +24,8 @@ describe("browser reader", () => {
   it("calls back with an error if read is called twice", (done) => {
     const buffer = new Buffer([0x00, 0x01, 0x02, 0x03, 0x04]);
     const reader = new Reader(buffer);
-    reader.read(0, 2, (err, res) => {});
-    reader.read(0, 2, (err, res) => {
+    reader.read(0, 2, () => {});
+    reader.read(0, 2, (err) => {
       expect(err instanceof Error).to.equal(true);
       done();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,10 +390,6 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
-
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"


### PR DESCRIPTION
Bluebird was only used for `promisifyAll` on the bag reader to easily add promise versions of a few internal methods.  Bluebird increases the bundle size of rosbag when used in the browser substantially, so I opted to remove it as a dependency and hand-roll the few places where promise versions of functions are called.