### PR TITLE
wrapper decompressFn  uint8array to Buffer because native uint8array …

### DIFF
--- a/lib/BagReader.js
+++ b/lib/BagReader.js
@@ -5,6 +5,7 @@
 // You may not use this file except in compliance with the License.
 
 import { parseHeader } from "./header";
+import { Buffer } from "buffer";
 import Time from "./Time";
 import nmerge from "./nmerge";
 
@@ -203,7 +204,7 @@ export default class BagReader {
           return callback(new Error(`Unsupported compression type ${chunk.compression}`));
         }
         const result = decompressFn(chunk.data);
-        chunk.data = result;
+        chunk.data = new Buffer(result);
       }
       const indices = this.readRecordsFromBuffer(
         buffer.slice(chunk.length),


### PR DESCRIPTION
wrapper decompressFn  uint8array to Buffer because native uint8array not has readInt32LE
when the lz4 lib decompress return native uint8array cause error