### PR TITLE
Add size to decompress callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ const bagOptions = {
   // the default is undefined which will apply no filter
   endTime? Time,
 
-  // decompression callbacks
-  // if your bag is compressed you can supply a callback to decompress
+  // decompression callbacks:
+  // if your bag is compressed you can supply a callback to decompress it
   // based on the compression type. The callback should accept a buffer of compressed bytes
-  // and return a buffer of uncompressed bytes
+  // and return a buffer of uncompressed bytes.  For examples on how to decompress lz4 and bz2 compressed bags
+  // please see the tests here: https://github.com/cruise-automation/rosbag.js/blob/master/test/rosbag.js#L139
+  // The decompression callback is also passed the uncompressedByteLength which is stored in the bag.
+  // This byte length can be used with some decompression libraries to increase decompression efficiency.
   decompress?: {|
-    bz2?: (buffer: Buffer) => Buffer,
-    lz4?: (buffer: Buffer) => Buffer,
+    bz2?: (buffer: Buffer, uncompressedByteLength: number) => Buffer,
+    lz4?: (buffer: Buffer, uncompressedByteLength: number) => Buffer,
   |}
 
   // by default the individual parsed binary messages will be parsed based on their [ROS message definition](http://wiki.ros.org/msg)

--- a/lib/BagReader.js
+++ b/lib/BagReader.js
@@ -202,7 +202,7 @@ export default class BagReader {
         if (!decompressFn) {
           return callback(new Error(`Unsupported compression type ${chunk.compression}`));
         }
-        const result = decompressFn(chunk.data);
+        const result = decompressFn(chunk.data, chunk.size);
         chunk.data = result;
       }
       const indices = this.readRecordsFromBuffer(

--- a/test/rosbag.js
+++ b/test/rosbag.js
@@ -175,5 +175,19 @@ describe("rosbag - high-level api", () => {
       expect(topics).to.have.length(1351);
       topics.forEach((topic) => expect(topic).to.equal("/turtle1/color_sensor"));
     });
+
+    it("calls decompress with the chunk size", async () => {
+      await fullyReadBag("example-lz4", {
+        startTime: new Time(1396293887, 846735850),
+        endTime: new Time(1396293887, 846735850),
+        topics: ["/turtle1/color_sensor"],
+        decompress: {
+          lz4: (buffer, size) => {
+            expect(size).to.equal(743449);
+            return new Buffer(lz4.decompress(buffer));
+          },
+        },
+      });
+    });
   });
 });

--- a/test/rosbag.js
+++ b/test/rosbag.js
@@ -184,7 +184,9 @@ describe("rosbag - high-level api", () => {
         decompress: {
           lz4: (buffer, size) => {
             expect(size).to.equal(743449);
-            return new Buffer(lz4.decompress(buffer));
+            const buff = new Buffer(lz4.decompress(buffer));
+            expect(buff.byteLength).to.equal(size);
+            return buff;
           },
         },
       });


### PR DESCRIPTION
In some decompression scenarios its helpful to know the expected decompressed size of the buffer.  This data is available in the chunk, and this PR adds it to the decompress callback.