### PR TITLE
Avoid allocating a new buffer for every file read.

### DIFF
--- a/lib/readers/node.js
+++ b/lib/readers/node.js
@@ -13,6 +13,7 @@ class Reader {
     this._filename = filename;
     this._fd = undefined;
     this._size = 0;
+    this._buffer = Buffer.allocUnsafe(0);
   }
 
   // open a file for reading
@@ -46,8 +47,10 @@ class Reader {
         return err ? cb(err) : this.read(offset, length, cb);
       });
     }
-    const buff = new Buffer(length);
-    return fs.read(this._fd, buff, 0, length, offset, (err, bytes, buff) => {
+    if (length > this._buffer.byteLength) {
+      this._buffer = Buffer.alloc(length);
+    }
+    return fs.read(this._fd, this._buffer, 0, length, offset, (err, bytes, buff) => {
       return cb(err, buff);
     });
   }


### PR DESCRIPTION
This more than doubles the reading speed in node.js.  A large majority of the work being done during read operations was running gc on the large file read buffers after they have been read.  I also updated to use `Buffer.alloc` instead of `new Buffer` as the later is deprecated in `node@10.x`.