### PR TITLE
Resolve unqualified types to fully qualified types

### DIFF
--- a/lib/MessageReader.js
+++ b/lib/MessageReader.js
@@ -123,30 +123,30 @@ class StandardTypeReader {
 
 // represents a single line in a message definition type
 // e.g. 'string name' 'CustomType[] foo' 'string[3] names'
-class Definition {
-  constructor(type, name, isArray = false, arrayLength = undefined) {
-    this.type = type;
-    this.name = name;
-    this.isArray = isArray;
-    this.arrayLength = arrayLength;
-    this.isComplex = !StandardTypeReader.prototype[type];
-  }
+function newDefinition(type, name, isArray = false, arrayLength = undefined) {
+  return {
+    type: type,
+    name: name,
+    isArray: isArray,
+    arrayLength: arrayLength,
+    isComplex: !StandardTypeReader.prototype[type],
+  };
 }
 
 // represents a definition of a custom type in a message definition
-class ComplexType {
-  constructor(name, definitions) {
-    this.name = name;
-    this.definitions = definitions;
-  }
+function newComplexType(name, definitions) {
+  return {
+    name: name,
+    definitions: definitions,
+  };
 }
 
-class CustomType {
-  constructor(type, name) {
-    this.isCustom = true;
-    this.name = name;
-    this.type = type;
-  }
+function newCustomType(type, name) {
+  return {
+    isCustom: true,
+    name: name,
+    type: type,
+  };
 }
 
 const buildType = (lines, customParsers) => {
@@ -167,7 +167,7 @@ const buildType = (lines, customParsers) => {
     const type = splits[0].trim();
     const name = splits[1].trim();
     if (Object.keys(customParsers).indexOf(type) > -1) {
-      customType = new CustomType(type, name);
+      customType = newCustomType(type, name);
     }
     if (type === "MSG:") {
       complexTypeName = name;
@@ -179,12 +179,12 @@ const buildType = (lines, customParsers) => {
       const typeSplits = type.split("[");
       const baseType = typeSplits[0];
       const arrayLength = parseInt(typeSplits[1].replace("]", ""), 10) || undefined;
-      instructions.push(new Definition(baseType, name, true, arrayLength));
+      instructions.push(newDefinition(baseType, name, true, arrayLength));
     } else {
-      instructions.push(new Definition(type, name));
+      instructions.push(newDefinition(type, name));
     }
   });
-  return new ComplexType(complexTypeName, customType || instructions);
+  return newComplexType(complexTypeName, customType || instructions);
 };
 
 const findTypeByName = (types, name = "") => {
@@ -221,7 +221,7 @@ const friendlyName = (name) => name.replace("/", "_");
 const createParser = (types) => {
   const unnamedTypes = types.filter((type) => !type.name);
   if (unnamedTypes.length !== 1) {
-    throw new Error("multiple unnmaed types");
+    throw new Error("multiple unnamed types");
   }
 
   const [unnamedType] = unnamedTypes;
@@ -355,6 +355,17 @@ export function getTypes(messageDefinition = "", customParsers = {}) {
     }
   });
   types.push(buildType(definitionLines, customParsers));
+
+  // Fix up complex type names
+  types.forEach(({ definitions }) => {
+    if (definitions.isCustom) return;
+    definitions.forEach((definition) => {
+      if (definition.isComplex) {
+        definition.type = findTypeByName(types, definition.type).name;
+      }
+    });
+  });
+
   return types;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,12 @@
 import Bag from "./bag";
 
 import BagReader from "./BagReader";
-import MessageReader from "./MessageReader";
+import MessageReader, { getTypes } from "./MessageReader";
 import Time from "./Time";
 
 // export this as a named export for es5 module compatibility
 const open = Bag.open;
 
-export { Time, BagReader, MessageReader, open };
+export { Time, BagReader, MessageReader, open, getTypes };
 
 export default Bag;

--- a/test/MessageReader.js
+++ b/test/MessageReader.js
@@ -17,22 +17,60 @@ const getStringBuffer = (str) => {
 const buildReader = (def) => new MessageReader(def);
 
 describe("MessageReader", () => {
-  it("lets you get just the types", () => {
-    const types = getTypes("string name");
-    expect(types).to.eql([
-      {
-        definitions: [
-          {
-            arrayLength: undefined,
-            isArray: false,
-            isComplex: false,
-            name: "name",
-            type: "string",
-          },
-        ],
-        name: undefined,
-      },
-    ]);
+  describe("getTypes", () => {
+    it("lets you get just the types", () => {
+      const types = getTypes("string name");
+      expect(types).to.eql([
+        {
+          definitions: [
+            {
+              arrayLength: undefined,
+              isArray: false,
+              isComplex: false,
+              name: "name",
+              type: "string",
+            },
+          ],
+          name: undefined,
+        },
+      ]);
+    });
+
+    it("resolves unqualified names", () => {
+      const messageDefinition = `
+        Point[] points
+        ============
+        MSG: geometry_msgs/Point
+        float64 x
+      `;
+      const types = getTypes(messageDefinition);
+      expect(types).to.eql([
+        {
+          definitions: [
+            {
+              arrayLength: undefined,
+              isArray: true,
+              isComplex: true,
+              name: "points",
+              type: "geometry_msgs/Point",
+            },
+          ],
+          name: undefined,
+        },
+        {
+          definitions: [
+            {
+              arrayLength: undefined,
+              isArray: false,
+              isComplex: false,
+              name: "x",
+              type: "float64",
+            },
+          ],
+          name: "geometry_msgs/Point",
+        },
+      ]);
+    });
   });
 
   describe("simple type", () => {


### PR DESCRIPTION
To make it easier to figure out which definitions refer to which types.

I also made the output of `getTypes` simple objects, instead of class
instances, as the latter may imply that there are any functions or so
callable on the instances, or that they’re not serialisable, and neither
is actually true.

Also actually export `getTypes`. :)

Test plan: actually tested this out in a real application, and wrote a
unit test.