### PR TITLE
Normalize type aliases

### DIFF
--- a/lib/MessageReader.js
+++ b/lib/MessageReader.js
@@ -39,11 +39,6 @@ class StandardTypeReader {
     return this.uint8() !== 0;
   }
 
-  // byte is deprecated in the rosbag spec but still used
-  byte() {
-    return this.int8();
-  }
-
   int8() {
     return this.view.getInt8(this.offset++);
   }
@@ -124,29 +119,27 @@ class StandardTypeReader {
 // represents a single line in a message definition type
 // e.g. 'string name' 'CustomType[] foo' 'string[3] names'
 function newDefinition(type, name, isArray = false, arrayLength = undefined) {
+  // Normalize deprecated aliases.
+  let normalizedType = type;
+  if (type === "char") normalizedType = "uint8";
+  if (type === "byte") normalizedType = "int8";
+
   return {
-    type: type,
-    name: name,
-    isArray: isArray,
-    arrayLength: arrayLength,
-    isComplex: !StandardTypeReader.prototype[type],
+    type: normalizedType,
+    name,
+    isArray,
+    arrayLength,
+    isComplex: !StandardTypeReader.prototype[normalizedType],
   };
 }
 
 // represents a definition of a custom type in a message definition
 function newComplexType(name, definitions) {
-  return {
-    name: name,
-    definitions: definitions,
-  };
+  return { name, definitions };
 }
 
 function newCustomType(type, name) {
-  return {
-    isCustom: true,
-    name: name,
-    type: type,
-  };
+  return { isCustom: true, name: name, type: type };
 }
 
 const buildType = (lines, customParsers) => {

--- a/test/MessageReader.js
+++ b/test/MessageReader.js
@@ -71,6 +71,31 @@ describe("MessageReader", () => {
         },
       ]);
     });
+
+    it("normalizes aliases", () => {
+      const types = getTypes("char x\nbyte y");
+      expect(types).to.eql([
+        {
+          definitions: [
+            {
+              arrayLength: undefined,
+              isArray: false,
+              isComplex: false,
+              name: "x",
+              type: "uint8",
+            },
+            {
+              arrayLength: undefined,
+              isArray: false,
+              isComplex: false,
+              name: "y",
+              type: "int8",
+            },
+          ],
+          name: undefined,
+        },
+      ]);
+    });
   });
 
   describe("simple type", () => {


### PR DESCRIPTION
So that the user of the `getTypes` function doesn’t have to worry about
those. See http://wiki.ros.org/msg

Test plan: added unit test; manually tested in actual application.