### PR TITLE
split message definition parsing out from MessageReader

### DIFF
--- a/lib/MessageReader.js
+++ b/lib/MessageReader.js
@@ -6,6 +6,7 @@
 
 import int53 from "int53";
 import { extractTime } from "./fields";
+import { parseMessageDefinition } from "./parseMessageDefinition";
 
 // this has hard-coded buffer reading functions for each
 // of the standard message types http://docs.ros.org/api/std_msgs/html/index-msg.html
@@ -116,94 +117,6 @@ class StandardTypeReader {
   }
 }
 
-function normalizeType(type) {
-  // Normalize deprecated aliases.
-  let normalizedType = type;
-  if (type === "char") normalizedType = "uint8";
-  if (type === "byte") normalizedType = "int8";
-  return normalizedType;
-}
-
-// represents a single line in a message definition type
-// e.g. 'string name' 'CustomType[] foo' 'string[3] names'
-function newDefinition(type, name, isArray = false, arrayLength = undefined) {
-  const normalizedType = normalizeType(type);
-  return {
-    type: normalizedType,
-    name,
-    isArray,
-    arrayLength,
-    isComplex: !StandardTypeReader.prototype[normalizedType],
-  };
-}
-
-// represents a definition of a custom type in a message definition
-function newComplexType(name, definitions) {
-  return { name, definitions };
-}
-
-function newCustomType(type, name) {
-  return { isCustom: true, name: name, type: type };
-}
-
-const buildType = (lines, customParsers) => {
-  const instructions = [];
-  let complexTypeName;
-  let customType;
-  lines.forEach((line) => {
-    // remove comments and extra whitespace from each line
-    const splits = line
-      .replace(/#.*/gi, "")
-      .split(" ")
-      .filter((word) => word);
-    if (!splits[1]) {
-      return;
-    }
-    // consume comments
-    const type = splits[0].trim();
-    const name = splits[1].trim();
-    if (Object.keys(customParsers).indexOf(type) > -1) {
-      customType = newCustomType(type, name);
-    }
-    if (type === "MSG:") {
-      complexTypeName = name;
-    } else if (name.indexOf("=") > -1 || splits.indexOf("=") > -1) {
-      // constant type parsing
-      const matches = line.match(/(\S+)\s*=\s*(.*)\s*/);
-      let value = matches[2];
-      if (type !== "string") {
-        try {
-          value = JSON.parse(value.replace(/\s*#.*/g, ""));
-        } catch (error) {
-          // eslint-disable-next-line no-console
-          console.warn(`Error in this constant definition: ${line}`);
-          throw error;
-        }
-        if (type === "bool") value = Boolean(value);
-      }
-      if ((type.includes("int") && value > Number.MAX_SAFE_INTEGER) || value < Number.MIN_SAFE_INTEGER) {
-        // eslint-disable-next-line no-console
-        console.warn(`Found integer constant outside safe integer range: ${line}`);
-      }
-      instructions.push({
-        type: normalizeType(type),
-        name: matches[1],
-        isConstant: true,
-        value,
-      });
-    } else if (type.indexOf("]") === type.length - 1) {
-      // array type parsing
-      const typeSplits = type.split("[");
-      const baseType = typeSplits[0];
-      const arrayLength = parseInt(typeSplits[1].replace("]", ""), 10) || undefined;
-      instructions.push(newDefinition(baseType, name, true, arrayLength));
-    } else {
-      instructions.push(newDefinition(type, name));
-    }
-  });
-  return newComplexType(complexTypeName, customType || instructions);
-};
-
 const findTypeByName = (types, name = "") => {
   const matches = types.filter((type) => {
     const typeName = type.name || "";
@@ -223,9 +136,6 @@ const findTypeByName = (types, name = "") => {
 };
 
 const constructorBody = (type) => {
-  if (type.definitions.isCustom) {
-    return ";";
-  }
   return type.definitions
     .map((def) => {
       return `this.${def.name} = undefined`;
@@ -260,11 +170,6 @@ Record.${friendlyName(t.name)} = function() {
   let stack = 0;
   const getReaderLines = (type, fieldName = "record") => {
     let readerLines = [];
-    if (type.definitions.isCustom) {
-      const def = type.definitions;
-      readerLines.push(`${fieldName}.${def.name} = customParsers["${def.type}"](reader)`);
-      return readerLines;
-    }
     type.definitions.forEach((def) => {
       if (def.isConstant) {
         return;
@@ -329,7 +234,7 @@ Record.${friendlyName(t.name)} = function() {
 
   const lines = getReaderLines(unnamedType).join("\n");
   const readerFn = `
-  return function read(reader, customParsers) {
+  return function read(reader) {
     var record = new Record();
     ${lines}
     return record;
@@ -345,60 +250,22 @@ Record.${friendlyName(t.name)} = function() {
     throw e;
   }
 
-  return function(buffer, customParsers) {
+  return function(buffer) {
     const reader = new StandardTypeReader(buffer);
-    return _read(reader, customParsers);
+    return _read(reader);
   };
 };
-
-export function getTypes(messageDefinition = "", customParsers = {}) {
-  // read all the lines and remove empties
-  const allLines = messageDefinition
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line);
-
-  let definitionLines = [];
-  const types = [];
-  // group lines into individual definitions
-  allLines.forEach((line) => {
-    // skip comment lines
-    if (line.indexOf("#") === 0) {
-      return;
-    }
-    // definitions are split by equal signs
-    if (line.indexOf("==") === 0) {
-      types.push(buildType(definitionLines, customParsers));
-      definitionLines = [];
-    } else {
-      definitionLines.push(line);
-    }
-  });
-  types.push(buildType(definitionLines, customParsers));
-
-  // Fix up complex type names
-  types.forEach(({ definitions }) => {
-    if (definitions.isCustom) return;
-    definitions.forEach((definition) => {
-      if (definition.isComplex) {
-        definition.type = findTypeByName(types, definition.type).name;
-      }
-    });
-  });
-
-  return types;
-}
 
 export default class MessageReader {
   // takes a multi-line string message definition and returns
   // a message reader which can be used to read messages based
   // on the message definition
-  constructor(messageDefinition = "", customParsers = {}) {
-    this.customParsers = customParsers;
-    this.reader = createParser(getTypes(messageDefinition, customParsers));
+  constructor(messageDefinition = "") {
+    const definitions = parseMessageDefinition(messageDefinition);
+    this.reader = createParser(definitions);
   }
 
   readMessage(buffer) {
-    return this.reader(buffer, this.customParsers);
+    return this.reader(buffer);
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,13 @@
 import Bag from "./bag";
 
 import BagReader from "./BagReader";
-import MessageReader, { getTypes } from "./MessageReader";
+import MessageReader from "./MessageReader";
+import { parseMessageDefinition as getTypes, builtins as rosPrimitiveTypes } from "./parseMessageDefinition";
 import Time from "./Time";
 
 // export this as a named export for es5 module compatibility
 const open = Bag.open;
 
-export { Time, BagReader, MessageReader, open, getTypes };
+export { Time, BagReader, MessageReader, open, getTypes, rosPrimitiveTypes };
 
 export default Bag;

--- a/lib/parseMessageDefinition.js
+++ b/lib/parseMessageDefinition.js
@@ -1,0 +1,171 @@
+// Copyright (c) 2018-present, GM Cruise LLC
+
+// This source code is licensed under the Apache License, Version 2.0,
+// found in the LICENSE file in the root directory of this source tree.
+// You may not use this file except in compliance with the License.
+
+// Set of built-in ros types. See http://wiki.ros.org/msg#Field_Types
+const builtins = new Set([
+  "string",
+  "bool",
+  "int8",
+  "uint8",
+  "int16",
+  "uint16",
+  "int32",
+  "uint32",
+  "float32",
+  "float64",
+  "int64",
+  "uint64",
+  "time",
+  "duration",
+]);
+
+function normalizeType(type) {
+  // Normalize deprecated aliases.
+  let normalizedType = type;
+  if (type === "char") normalizedType = "uint8";
+  if (type === "byte") normalizedType = "int8";
+  return normalizedType;
+}
+
+// represents a single line in a message definition type
+// e.g. 'string name' 'CustomType[] foo' 'string[3] names'
+function newDefinition(type, name, isArray = false, arrayLength = undefined) {
+  const normalizedType = normalizeType(type);
+  return {
+    type: normalizedType,
+    name,
+    isArray,
+    arrayLength,
+    isComplex: !builtins.has(normalizedType),
+  };
+}
+
+const buildType = (lines) => {
+  const definitions = [];
+  let complexTypeName;
+  lines.forEach((line) => {
+    // remove comments and extra whitespace from each line
+    const splits = line
+      .replace(/#.*/gi, "")
+      .split(" ")
+      .filter((word) => word);
+    if (!splits[1]) {
+      return;
+    }
+    // consume comments
+    const type = splits[0].trim();
+    const name = splits[1].trim();
+    if (type === "MSG:") {
+      complexTypeName = name;
+    } else if (name.indexOf("=") > -1 || splits.indexOf("=") > -1) {
+      // constant type parsing
+      const matches = line.match(/(\S+)\s*=\s*(.*)\s*/);
+      let value = matches[2];
+      if (type !== "string") {
+        try {
+          value = JSON.parse(value.replace(/\s*#.*/g, ""));
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.warn(`Error in this constant definition: ${line}`);
+          throw error;
+        }
+        if (type === "bool") value = Boolean(value);
+      }
+      if ((type.includes("int") && value > Number.MAX_SAFE_INTEGER) || value < Number.MIN_SAFE_INTEGER) {
+        // eslint-disable-next-line no-console
+        console.warn(`Found integer constant outside safe integer range: ${line}`);
+      }
+      definitions.push({
+        type: normalizeType(type),
+        name: matches[1],
+        isConstant: true,
+        value,
+      });
+    } else if (type.indexOf("]") === type.length - 1) {
+      // array type parsing
+      const typeSplits = type.split("[");
+      const baseType = typeSplits[0];
+      const arrayLength = parseInt(typeSplits[1].replace("]", ""), 10) || undefined;
+      definitions.push(newDefinition(baseType, name, true, arrayLength));
+    } else {
+      definitions.push(newDefinition(type, name));
+    }
+  });
+  return { name: complexTypeName, definitions };
+};
+
+const findTypeByName = (types, name = "") => {
+  const matches = types.filter((type) => {
+    const typeName = type.name || "";
+    // if the search is empty, return unnamed types
+    if (!name) {
+      return !typeName;
+    }
+    // return if the search is in the type name
+    // or matches exactly if a fully-qualified name match is passed to us
+    const nameEnd = name.indexOf("/") > -1 ? name : `/${name}`;
+    return typeName.endsWith(nameEnd);
+  });
+  if (matches.length !== 1) {
+    throw new Error(`Expected 1 top level type definition for '${name}' but found ${matches.length}`);
+  }
+  return matches[0];
+};
+
+export { builtins };
+
+// Given a raw message definition string, parse it into an object representation.
+// Example return value:
+// [{
+//   name: undefined,
+//   definitions: [
+//     {
+//       arrayLength: undefined,
+//       isArray: false,
+//       isComplex: false,
+//       name: "name",
+//       type: "string",
+//     }, ...
+//   ],
+// }, ... ]
+//
+// See unit tests for more examples.
+export function parseMessageDefinition(messageDefinition = "") {
+  // read all the lines and remove empties
+  const allLines = messageDefinition
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line);
+
+  let definitionLines = [];
+  const types = [];
+  // group lines into individual definitions
+  allLines.forEach((line) => {
+    // skip comment lines
+    if (line.indexOf("#") === 0) {
+      return;
+    }
+    // definitions are split by equal signs
+    if (line.indexOf("==") === 0) {
+      types.push(buildType(definitionLines));
+      definitionLines = [];
+    } else {
+      definitionLines.push(line);
+    }
+  });
+  types.push(buildType(definitionLines));
+
+  // Fix up complex type names
+  types.forEach(({ definitions }) => {
+    definitions.forEach((definition) => {
+      if (definition.isComplex) {
+        definition.type = findTypeByName(types, definition.type).name;
+      }
+    });
+  });
+
+  return types;
+}

--- a/test/parseMessageDefinition.js
+++ b/test/parseMessageDefinition.js
@@ -1,0 +1,265 @@
+// Copyright (c) 2018-present, GM Cruise LLC
+
+// This source code is licensed under the Apache License, Version 2.0,
+// found in the LICENSE file in the root directory of this source tree.
+// You may not use this file except in compliance with the License.
+
+import { expect } from "chai";
+import { parseMessageDefinition } from "../lib/parseMessageDefinition";
+
+describe("parseMessageDefinition", () => {
+  it("parses a single field from a single message", () => {
+    const types = parseMessageDefinition("string name");
+    expect(types).to.eql([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "name",
+            type: "string",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("resolves unqualified names", () => {
+    const messageDefinition = `
+      Point[] points
+      ============
+      MSG: geometry_msgs/Point
+      float64 x
+    `;
+    const types = parseMessageDefinition(messageDefinition);
+    expect(types).to.eql([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: true,
+            isComplex: true,
+            name: "points",
+            type: "geometry_msgs/Point",
+          },
+        ],
+        name: undefined,
+      },
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "x",
+            type: "float64",
+          },
+        ],
+        name: "geometry_msgs/Point",
+      },
+    ]);
+  });
+
+  it("normalizes aliases", () => {
+    const types = parseMessageDefinition("char x\nbyte y");
+    expect(types).to.eql([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "x",
+            type: "uint8",
+          },
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "y",
+            type: "int8",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("ignores comment lines", () => {
+    const messageDefinition = `
+    # your first name goes here
+    string firstName
+
+    # last name here
+    ### foo bar baz?
+    string lastName
+    `;
+    const types = parseMessageDefinition(messageDefinition);
+    expect(types).to.eql([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "firstName",
+            type: "string",
+          },
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "lastName",
+            type: "string",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("parses variable length string array", () => {
+    const types = parseMessageDefinition("string[] names");
+    expect(types).to.eql([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: true,
+            isComplex: false,
+            name: "names",
+            type: "string",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("parses fixed length string array", () => {
+    const types = parseMessageDefinition("string[3] names");
+    expect(types).to.eql([
+      {
+        definitions: [
+          {
+            arrayLength: 3,
+            isArray: true,
+            isComplex: false,
+            name: "names",
+            type: "string",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("parses nested complex types", () => {
+    const messageDefinition = `
+    string username
+    Account account
+    ============
+    MSG: custom_type/Account
+    string name
+    uint16 id
+    `;
+    const types = parseMessageDefinition(messageDefinition);
+    expect(types).to.eql([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "username",
+            type: "string",
+          },
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: true,
+            name: "account",
+            type: "custom_type/Account",
+          },
+        ],
+        name: undefined,
+      },
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "name",
+            type: "string",
+          },
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "id",
+            type: "uint16",
+          },
+        ],
+        name: "custom_type/Account",
+      },
+    ]);
+  });
+
+  it("returns constants", () => {
+    const messageDefinition = `
+      uint32 foo = 55
+      int32 bar=-11 # Comment # another comment
+      float32 baz= \t -32.25
+      bool someBoolean = 0
+      string fooStr = Foo    ${""}
+      string EXAMPLE="#comments" are ignored, and leading and trailing whitespace removed
+    `;
+    const types = parseMessageDefinition(messageDefinition);
+    expect(types).to.eql([
+      {
+        definitions: [
+          {
+            name: "foo",
+            type: "uint32",
+            isConstant: true,
+            value: 55,
+          },
+          {
+            name: "bar",
+            type: "int32",
+            isConstant: true,
+            value: -11,
+          },
+          {
+            name: "baz",
+            type: "float32",
+            isConstant: true,
+            value: -32.25,
+          },
+          {
+            name: "someBoolean",
+            type: "bool",
+            isConstant: true,
+            value: false,
+          },
+          {
+            name: "fooStr",
+            type: "string",
+            isConstant: true,
+            value: "Foo",
+          },
+          {
+            name: "EXAMPLE",
+            type: "string",
+            isConstant: true,
+            value: '"#comments" are ignored, and leading and trailing whitespace removed', // eslint-disable-line quotes
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Reading a message definition and building a de-serializer are two
separate steps. Splitting the definition parsing from de-serialization
decouples the two and allows for refactoring each while still
maintaining interface boundaries.

---

This PR removes the _customParsers_ feature which is not document and partially functioning.