### PR TITLE
Don’t return constants on messages

### DIFF
--- a/lib/MessageReader.js
+++ b/lib/MessageReader.js
@@ -137,6 +137,7 @@ const findTypeByName = (types, name = "") => {
 
 const constructorBody = (type) => {
   return type.definitions
+    .filter((def) => !def.isConstant)
     .map((def) => {
       return `this.${def.name} = undefined`;
     })

--- a/lib/MessageReader.test.js
+++ b/lib/MessageReader.test.js
@@ -388,10 +388,14 @@ describe("MessageReader", () => {
       const reader = buildReader(withBytesAndBools);
       const buffer = Buffer.concat([Buffer.from([0x01]), Buffer.from([0x00]), getStringBuffer("foo")]);
 
-      const { level, status } = reader.readMessage(buffer);
+      const message = reader.readMessage(buffer);
+      const { level, status } = message;
       expect(level).to.equal(true);
       expect(status.level).to.equal(0);
       expect(status.name).to.equal("foo");
+
+      // We shouldn't expose constants on the message.
+      expect(Object.keys(message).includes("STALE")).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Otherwise you get a whole bunch of undefined keys for constants, which
is not great when printing an entire message, e.g. for debugging.

Test plan: manual; added unit test.