### PR TITLE
convert tests from chai to jest assertions

### DIFF
--- a/lib/MessageReader.test.js
+++ b/lib/MessageReader.test.js
@@ -4,7 +4,6 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import { expect } from "chai";
 import MessageReader from "./MessageReader";
 
 const getStringBuffer = (str) => {
@@ -23,7 +22,7 @@ describe("MessageReader", () => {
       cb(buffer);
       it(`parses buffer ${JSON.stringify(buffer)} containing ${type}`, () => {
         const reader = buildReader(`${type} foo`);
-        expect(reader.readMessage(buffer)).to.eql({
+        expect(reader.readMessage(buffer)).toEqual({
           foo: expected,
         });
       });
@@ -41,7 +40,7 @@ describe("MessageReader", () => {
     it("parses string", () => {
       const reader = buildReader("string name");
       const buff = getStringBuffer("test");
-      expect(reader.readMessage(buff)).to.eql({
+      expect(reader.readMessage(buff)).toEqual({
         name: "test",
       });
     });
@@ -56,7 +55,7 @@ describe("MessageReader", () => {
       buff.writeUInt32LE(seconds);
       buff.writeUInt32LE(1000000, 4);
       now.setMilliseconds(1);
-      expect(reader.readMessage(buff)).to.eql({
+      expect(reader.readMessage(buff)).toEqual({
         right_now: {
           nsec: 1000000,
           sec: seconds,
@@ -76,7 +75,7 @@ describe("MessageReader", () => {
     `;
     const reader = buildReader(messageDefinition);
     const buffer = Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar")]);
-    expect(reader.readMessage(buffer)).to.eql({
+    expect(reader.readMessage(buffer)).toEqual({
       firstName: "foo",
       lastName: "bar",
     });
@@ -92,7 +91,7 @@ describe("MessageReader", () => {
         getStringBuffer("bar"),
         getStringBuffer("baz"),
       ]);
-      expect(reader.readMessage(buffer)).to.eql({
+      expect(reader.readMessage(buffer)).toEqual({
         names: ["foo", "bar", "baz"],
       });
     });
@@ -102,13 +101,13 @@ describe("MessageReader", () => {
       const parser2 = buildReader("string[2] names");
       const parser3 = buildReader("string[3] names");
       const buffer = Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), getStringBuffer("baz")]);
-      expect(parser1.readMessage(buffer)).to.eql({
+      expect(parser1.readMessage(buffer)).toEqual({
         names: ["foo"],
       });
-      expect(parser2.readMessage(buffer)).to.eql({
+      expect(parser2.readMessage(buffer)).toEqual({
         names: ["foo", "bar"],
       });
-      expect(parser3.readMessage(buffer)).to.eql({
+      expect(parser3.readMessage(buffer)).toEqual({
         names: ["foo", "bar", "baz"],
       });
     });
@@ -121,7 +120,7 @@ describe("MessageReader", () => {
       ]);
 
       const message = reader.readMessage(buffer);
-      expect(message).to.eql({ names: [] });
+      expect(message).toEqual({ names: [] });
     });
 
     describe("typed arrays", () => {
@@ -130,16 +129,16 @@ describe("MessageReader", () => {
         const buffer = Buffer.from([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]);
         const result = reader.readMessage(buffer);
         const { values, after } = result;
-        expect(values instanceof Uint8Array).to.equal(true);
-        expect(values.buffer).to.equal(buffer.buffer);
-        expect(values.length).to.equal(3);
-        expect(values[0]).to.equal(1);
-        expect(values[1]).to.equal(2);
-        expect(values[2]).to.equal(3);
+        expect(values instanceof Uint8Array).toBe(true);
+        expect(values.buffer).toBe(buffer.buffer);
+        expect(values.length).toBe(3);
+        expect(values[0]).toBe(1);
+        expect(values[1]).toBe(2);
+        expect(values[2]).toBe(3);
 
         // Ensure the next value after the array gets read properly
-        expect(after).to.equal(4);
-        expect(values.buffer.byteLength).to.be.greaterThan(3);
+        expect(after).toBe(4);
+        expect(values.buffer.byteLength).toBeGreaterThan(3);
       });
 
       it("parses uint8[] with a fixed length", () => {
@@ -147,16 +146,16 @@ describe("MessageReader", () => {
         const buffer = Buffer.from([0x01, 0x02, 0x03, 0x04]);
         const result = reader.readMessage(buffer);
         const { values, after } = result;
-        expect(values instanceof Uint8Array).to.equal(true);
-        expect(values.buffer).to.equal(buffer.buffer);
-        expect(values.length).to.equal(3);
-        expect(values[0]).to.equal(1);
-        expect(values[1]).to.equal(2);
-        expect(values[2]).to.equal(3);
+        expect(values instanceof Uint8Array).toBe(true);
+        expect(values.buffer).toBe(buffer.buffer);
+        expect(values.length).toBe(3);
+        expect(values[0]).toBe(1);
+        expect(values[1]).toBe(2);
+        expect(values[2]).toBe(3);
 
         // Ensure the next value after the array gets read properly
-        expect(after).to.equal(4);
-        expect(values.buffer.byteLength).to.be.greaterThan(3);
+        expect(after).toBe(4);
+        expect(values.buffer.byteLength).toBeGreaterThan(3);
       });
 
       it("int8[] uses the same backing buffer", () => {
@@ -164,16 +163,16 @@ describe("MessageReader", () => {
         const buffer = new Buffer([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]);
         const result = reader.readMessage(buffer);
         const { values, after } = result;
-        expect(values instanceof Int8Array).to.equal(true);
-        expect(values.buffer).to.equal(buffer.buffer);
-        expect(values.length).to.equal(3);
-        expect(values[0]).to.equal(1);
-        expect(values[1]).to.equal(2);
-        expect(values[2]).to.equal(3);
+        expect(values instanceof Int8Array).toBe(true);
+        expect(values.buffer).toBe(buffer.buffer);
+        expect(values.length).toBe(3);
+        expect(values[0]).toBe(1);
+        expect(values[1]).toBe(2);
+        expect(values[2]).toBe(3);
 
         // Ensure the next value after the array gets read properly
-        expect(after).to.equal(4);
-        expect(values.buffer.byteLength).to.be.greaterThan(3);
+        expect(after).toBe(4);
+        expect(values.buffer.byteLength).toBeGreaterThan(3);
       });
 
       it("parses int8[] with a fixed length", () => {
@@ -181,16 +180,16 @@ describe("MessageReader", () => {
         const buffer = new Buffer([0x01, 0x02, 0x03, 0x04]);
         const result = reader.readMessage(buffer);
         const { values, after } = result;
-        expect(values instanceof Int8Array).to.equal(true);
-        expect(values.buffer).to.equal(buffer.buffer);
-        expect(values.length).to.equal(3);
-        expect(values[0]).to.equal(1);
-        expect(values[1]).to.equal(2);
-        expect(values[2]).to.equal(3);
+        expect(values instanceof Int8Array).toBe(true);
+        expect(values.buffer).toBe(buffer.buffer);
+        expect(values.length).toBe(3);
+        expect(values[0]).toBe(1);
+        expect(values[1]).toBe(2);
+        expect(values[2]).toBe(3);
 
         // Ensure the next value after the array gets read properly
-        expect(after).to.equal(4);
-        expect(values.buffer.byteLength).to.be.greaterThan(3);
+        expect(after).toBe(4);
+        expect(values.buffer.byteLength).toBeGreaterThan(3);
       });
 
       it("parses combinations of typed arrays", () => {
@@ -199,17 +198,17 @@ describe("MessageReader", () => {
         const result = reader.readMessage(buffer);
         const { first, second } = result;
 
-        expect(first instanceof Int8Array).to.equal(true);
-        expect(first.buffer).to.equal(buffer.buffer);
-        expect(first.length).to.equal(2);
-        expect(first[0]).to.equal(1);
-        expect(first[1]).to.equal(2);
+        expect(first instanceof Int8Array).toBe(true);
+        expect(first.buffer).toBe(buffer.buffer);
+        expect(first.length).toBe(2);
+        expect(first[0]).toBe(1);
+        expect(first[1]).toBe(2);
 
-        expect(second instanceof Uint8Array).to.equal(true);
-        expect(second.buffer).to.equal(buffer.buffer);
-        expect(second.length).to.equal(2);
-        expect(second[0]).to.equal(3);
-        expect(second[1]).to.equal(4);
+        expect(second instanceof Uint8Array).toBe(true);
+        expect(second.buffer).toBe(buffer.buffer);
+        expect(second.length).toBe(2);
+        expect(second[0]).toBe(3);
+        expect(second[1]).toBe(4);
       });
     });
   });
@@ -218,7 +217,7 @@ describe("MessageReader", () => {
     it("parses single complex type", () => {
       const reader = buildReader("string firstName \n string lastName\nuint16 age");
       const buffer = Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), new Buffer([0x05, 0x00])]);
-      expect(reader.readMessage(buffer)).to.eql({
+      expect(reader.readMessage(buffer)).toEqual({
         firstName: "foo",
         lastName: "bar",
         age: 5,
@@ -236,7 +235,7 @@ describe("MessageReader", () => {
       `;
       const reader = buildReader(messageDefinition);
       const buffer = Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), new Buffer([100, 0x00])]);
-      expect(reader.readMessage(buffer)).to.eql({
+      expect(reader.readMessage(buffer)).toEqual({
         username: "foo",
         account: {
           name: "bar",
@@ -264,7 +263,7 @@ describe("MessageReader", () => {
         getStringBuffer("baz"),
         new Buffer([101, 0x00]),
       ]);
-      expect(reader.readMessage(buffer)).to.eql({
+      expect(reader.readMessage(buffer)).toEqual({
         username: "foo",
         accounts: [
           {
@@ -328,7 +327,7 @@ describe("MessageReader", () => {
         new Buffer([0x00, 0x00, 0x00, 0x00]),
       ]);
 
-      expect(reader.readMessage(buffer)).to.eql({
+      expect(reader.readMessage(buffer)).toEqual({
         username: "foo",
         accounts: [
           {
@@ -390,12 +389,12 @@ describe("MessageReader", () => {
 
       const message = reader.readMessage(buffer);
       const { level, status } = message;
-      expect(level).to.equal(true);
-      expect(status.level).to.equal(0);
-      expect(status.name).to.equal("foo");
+      expect(level).toBe(true);
+      expect(status.level).toBe(0);
+      expect(status.name).toBe("foo");
 
       // We shouldn't expose constants on the message.
-      expect(Object.keys(message).includes("STALE")).to.equal(false);
+      expect(Object.keys(message).includes("STALE")).toBe(false);
     });
   });
 });

--- a/lib/Time.test.js
+++ b/lib/Time.test.js
@@ -4,7 +4,6 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import { expect } from "chai";
 import { Time } from ".";
 
 describe("Time", () => {
@@ -12,56 +11,56 @@ describe("Time", () => {
 
   it("can be created from a date", () => {
     const time = Time.fromDate(date);
-    expect(time.sec).to.equal(Math.floor(1511798097280 / 1000));
-    expect(time.nsec).to.equal(280000000);
+    expect(time.sec).toBe(Math.floor(1511798097280 / 1000));
+    expect(time.nsec).toBe(280000000);
   });
 
   it("can convert to a date", () => {
     const time = new Time(1511798097, 280000000);
-    expect(time.toDate()).to.eql(date);
+    expect(time.toDate()).toEqual(date);
   });
 
   it("can sort by compare", () => {
     const times = [new Time(1, 1), new Time(0, 0), new Time(1, 0), new Time(0, 1)];
     times.sort(Time.compare);
-    expect(times).to.eql([{ sec: 0, nsec: 0 }, { sec: 0, nsec: 1 }, { sec: 1, nsec: 0 }, { sec: 1, nsec: 1 }]);
+    expect(times).toEqual([{ sec: 0, nsec: 0 }, { sec: 0, nsec: 1 }, { sec: 1, nsec: 0 }, { sec: 1, nsec: 1 }]);
   });
 
   it("has lessThan functionality", () => {
     const min = new Time(0, 0);
     const oneNano = new Time(0, 1);
     const max = new Time(1, 1);
-    expect(Time.isLessThan(min, min)).to.equal(false);
-    expect(Time.isLessThan(max, min)).to.equal(false);
-    expect(Time.isLessThan(oneNano, min)).to.equal(false);
-    expect(Time.isLessThan(min, oneNano)).to.equal(true);
-    expect(Time.isLessThan(min, max)).to.equal(true);
+    expect(Time.isLessThan(min, min)).toBe(false);
+    expect(Time.isLessThan(max, min)).toBe(false);
+    expect(Time.isLessThan(oneNano, min)).toBe(false);
+    expect(Time.isLessThan(min, oneNano)).toBe(true);
+    expect(Time.isLessThan(min, max)).toBe(true);
   });
 
   it("has greaterThan functionality", () => {
     const min = new Time(0, 0);
     const oneNano = new Time(0, 1);
     const max = new Time(1, 1);
-    expect(Time.isGreaterThan(min, min)).to.equal(false);
-    expect(Time.isGreaterThan(max, min)).to.equal(true);
-    expect(Time.isGreaterThan(oneNano, min)).to.equal(true);
-    expect(Time.isGreaterThan(min, oneNano)).to.equal(false);
-    expect(Time.isGreaterThan(min, max)).to.equal(false);
+    expect(Time.isGreaterThan(min, min)).toBe(false);
+    expect(Time.isGreaterThan(max, min)).toBe(true);
+    expect(Time.isGreaterThan(oneNano, min)).toBe(true);
+    expect(Time.isGreaterThan(min, oneNano)).toBe(false);
+    expect(Time.isGreaterThan(min, max)).toBe(false);
   });
 
   it("tests for sameness", () => {
     const min = new Time(0, 0);
     const min2 = new Time(0, 0);
     const oneNano = new Time(0, 1);
-    expect(min === min2).to.equal(false);
-    expect(Time.areSame(min, min2)).to.equal(true);
-    expect(Time.areSame(min, oneNano)).to.equal(false);
+    expect(min === min2).toBe(false);
+    expect(Time.areSame(min, min2)).toBe(true);
+    expect(Time.areSame(min, oneNano)).toBe(false);
   });
 
   it("can add two times together", () => {
-    expect(Time.add(new Time(0, 0), new Time(0, 0))).to.eql({ sec: 0, nsec: 0 });
-    expect(Time.add(new Time(1, 100), new Time(2, 200))).to.eql({ sec: 3, nsec: 300 });
-    expect(Time.add(new Time(0, 1e9 - 1), new Time(0, 1))).to.eql({ sec: 1, nsec: 0 });
-    expect(Time.add(new Time(0, 1e9 - 1), new Time(0, 101))).to.eql({ sec: 1, nsec: 100 });
+    expect(Time.add(new Time(0, 0), new Time(0, 0))).toEqual({ sec: 0, nsec: 0 });
+    expect(Time.add(new Time(1, 100), new Time(2, 200))).toEqual({ sec: 3, nsec: 300 });
+    expect(Time.add(new Time(0, 1e9 - 1), new Time(0, 1))).toEqual({ sec: 1, nsec: 0 });
+    expect(Time.add(new Time(0, 1e9 - 1), new Time(0, 101))).toEqual({ sec: 1, nsec: 100 });
   });
 });

--- a/lib/bag.test.js
+++ b/lib/bag.test.js
@@ -5,7 +5,6 @@
 // You may not use this file except in compliance with the License.
 
 import fs from "fs";
-import { expect } from "chai";
 import lz4 from "lz4js";
 import compress from "compressjs";
 
@@ -20,7 +19,7 @@ function getFixture(filename = FILENAME) {
 
 async function fullyReadBag(name, opts) {
   const filename = getFixture(name);
-  expect(fs.existsSync(filename)).to.eql(true);
+  expect(fs.existsSync(filename)).toBe(true);
   const bag = await Bag.open(filename);
   const messages = [];
   await bag.readMessages(opts, (msg) => messages.push(msg));
@@ -31,11 +30,11 @@ describe("rosbag - high-level api", () => {
   const testNumberOfMessages = (name, expected, opts = {}, done) => {
     it(`finds ${expected} messages in ${name} with ${JSON.stringify(opts)}`, async () => {
       const messages = await fullyReadBag(name, opts);
-      expect(messages).to.have.length(expected);
+      expect(messages).toHaveLength(expected);
       if (expected) {
         const [message] = messages;
-        expect(message).to.not.equal(undefined);
-        expect(message.timestamp).to.not.equal(undefined);
+        expect(message).toBeDefined();
+        expect(message.timestamp).toBeDefined();
       }
       if (done) {
         done(messages);
@@ -69,9 +68,9 @@ describe("rosbag - high-level api", () => {
     },
     (messages) => {
       // assert that only topic, header, and timestamp were retained
-      expect(Object.keys(messages[0]).length).to.equal(3);
+      expect(Object.keys(messages[0]).length).toBe(3);
       // assert that the mapEach function was only invoked once
-      expect(calledMapEach).to.equal(8647);
+      expect(calledMapEach).toBe(8647);
     }
   );
 
@@ -80,14 +79,14 @@ describe("rosbag - high-level api", () => {
     const bag = await Bag.open(filename);
     const messages = [];
     await bag.readMessages({}, (msg) => messages.push(msg));
-    expect(messages[0].chunkOffset).to.equal(0);
-    expect(messages[0].totalChunks).to.equal(1);
+    expect(messages[0].chunkOffset).toBe(0);
+    expect(messages[0].totalChunks).toBe(1);
   });
 
   it("reads topics", async () => {
     const bag = await Bag.open(getFixture());
     const topics = Object.values(bag.connections).map((con) => con.topic);
-    expect(topics).to.eql([
+    expect(topics).toEqual([
       "/rosout",
       "/turtle1/color_sensor",
       "/rosout",
@@ -108,11 +107,11 @@ describe("rosbag - high-level api", () => {
     const messages = await fullyReadBag(FILENAME, opts);
     const [msg] = messages;
     const { linear } = msg.message;
-    expect(msg.timestamp).to.eql({
+    expect(msg.timestamp).toEqual({
       sec: 1396293889,
       nsec: 366115136,
     });
-    expect(linear).to.eql({
+    expect(linear).toEqual({
       x: 2,
       y: 0,
       z: 0,
@@ -122,17 +121,17 @@ describe("rosbag - high-level api", () => {
   it("reads messages filtered to a specific topic", async () => {
     const messages = await fullyReadBag(FILENAME, { topics: ["/turtle1/color_sensor"] });
     const topics = messages.map((msg) => msg.topic);
-    expect(topics).to.have.length(1351);
-    topics.forEach((topic) => expect(topic).to.equal("/turtle1/color_sensor"));
+    expect(topics).toHaveLength(1351);
+    topics.forEach((topic) => expect(topic).toBe("/turtle1/color_sensor"));
   });
 
   it("reads messages filtered to multiple topics", async () => {
     const opts = { topics: ["/turtle1/color_sensor", "/turtle2/color_sensor"] };
     const messages = await fullyReadBag(FILENAME, opts);
     const topics = messages.map((msg) => msg.topic);
-    expect(topics).to.have.length(2695);
+    expect(topics).toHaveLength(2695);
     topics.forEach((topic) =>
-      expect(topic === "/turtle1/color_sensor" || topic === "/turtle2/color_sensor").to.equal(true)
+      expect(topic === "/turtle1/color_sensor" || topic === "/turtle2/color_sensor").toBe(true)
     );
   });
 
@@ -143,10 +142,10 @@ describe("rosbag - high-level api", () => {
       try {
         await bag.readMessages({}, () => {});
       } catch (e) {
-        expect(e.message).to.contain("compression");
+        expect(e.message).toContain("compression");
         errorThrown = true;
       }
-      expect(errorThrown).to.equal(true);
+      expect(errorThrown).toBe(true);
     });
 
     it("reads bz2 with supplied decompression callback", async () => {
@@ -160,8 +159,8 @@ describe("rosbag - high-level api", () => {
         },
       });
       const topics = messages.map((msg) => msg.topic);
-      expect(topics).to.have.length(1351);
-      topics.forEach((topic) => expect(topic).to.equal("/turtle1/color_sensor"));
+      expect(topics).toHaveLength(1351);
+      topics.forEach((topic) => expect(topic).toBe("/turtle1/color_sensor"));
     });
 
     it("reads lz4 with supplied decompression callback", async () => {
@@ -172,8 +171,8 @@ describe("rosbag - high-level api", () => {
         },
       });
       const topics = messages.map((msg) => msg.topic);
-      expect(topics).to.have.length(1351);
-      topics.forEach((topic) => expect(topic).to.equal("/turtle1/color_sensor"));
+      expect(topics).toHaveLength(1351);
+      topics.forEach((topic) => expect(topic).toBe("/turtle1/color_sensor"));
     });
 
     it("calls decompress with the chunk size", async () => {
@@ -183,9 +182,9 @@ describe("rosbag - high-level api", () => {
         topics: ["/turtle1/color_sensor"],
         decompress: {
           lz4: (buffer, size) => {
-            expect(size).to.equal(743449);
+            expect(size).toBe(743449);
             const buff = new Buffer(lz4.decompress(buffer));
-            expect(buff.byteLength).to.equal(size);
+            expect(buff.byteLength).toBe(size);
             return buff;
           },
         },

--- a/lib/parseMessageDefinition.test.js
+++ b/lib/parseMessageDefinition.test.js
@@ -4,13 +4,12 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import { expect } from "chai";
 import { parseMessageDefinition } from "../lib/parseMessageDefinition";
 
 describe("parseMessageDefinition", () => {
   it("parses a single field from a single message", () => {
     const types = parseMessageDefinition("string name");
-    expect(types).to.eql([
+    expect(types).toEqual([
       {
         definitions: [
           {
@@ -34,7 +33,7 @@ describe("parseMessageDefinition", () => {
       float64 x
     `;
     const types = parseMessageDefinition(messageDefinition);
-    expect(types).to.eql([
+    expect(types).toEqual([
       {
         definitions: [
           {
@@ -64,7 +63,7 @@ describe("parseMessageDefinition", () => {
 
   it("normalizes aliases", () => {
     const types = parseMessageDefinition("char x\nbyte y");
-    expect(types).to.eql([
+    expect(types).toEqual([
       {
         definitions: [
           {
@@ -97,7 +96,7 @@ describe("parseMessageDefinition", () => {
     string lastName
     `;
     const types = parseMessageDefinition(messageDefinition);
-    expect(types).to.eql([
+    expect(types).toEqual([
       {
         definitions: [
           {
@@ -122,7 +121,7 @@ describe("parseMessageDefinition", () => {
 
   it("parses variable length string array", () => {
     const types = parseMessageDefinition("string[] names");
-    expect(types).to.eql([
+    expect(types).toEqual([
       {
         definitions: [
           {
@@ -140,7 +139,7 @@ describe("parseMessageDefinition", () => {
 
   it("parses fixed length string array", () => {
     const types = parseMessageDefinition("string[3] names");
-    expect(types).to.eql([
+    expect(types).toEqual([
       {
         definitions: [
           {
@@ -166,7 +165,7 @@ describe("parseMessageDefinition", () => {
     uint16 id
     `;
     const types = parseMessageDefinition(messageDefinition);
-    expect(types).to.eql([
+    expect(types).toEqual([
       {
         definitions: [
           {
@@ -218,7 +217,7 @@ describe("parseMessageDefinition", () => {
       string EXAMPLE="#comments" are ignored, and leading and trailing whitespace removed
     `;
     const types = parseMessageDefinition(messageDefinition);
-    expect(types).to.eql([
+    expect(types).toEqual([
       {
         definitions: [
           {

--- a/lib/readers/browser.test.js
+++ b/lib/readers/browser.test.js
@@ -4,7 +4,6 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import { expect } from "chai";
 import Reader from "./browser";
 
 // tiny polyfill for the parts of the FileReader API we use
@@ -20,11 +19,11 @@ describe("browser reader", () => {
     const buffer = new Buffer([0x00, 0x01, 0x02, 0x03, 0x04]);
     const reader = new Reader(buffer);
     reader.read(0, 2, (err, res) => {
-      expect(err).to.equal(null);
-      expect(res).to.have.length(2);
-      expect(res instanceof Buffer).to.equal(true);
-      expect(res[0]).to.equal(0x00);
-      expect(res[1]).to.equal(0x01);
+      expect(err).toBeNull();
+      expect(res).toHaveLength(2);
+      expect(res instanceof Buffer).toBe(true);
+      expect(res[0]).toBe(0x00);
+      expect(res[1]).toBe(0x01);
       done();
     });
   });
@@ -34,7 +33,7 @@ describe("browser reader", () => {
     const reader = new Reader(buffer);
     reader.read(0, 2, () => {});
     reader.read(0, 2, (err) => {
-      expect(err instanceof Error).to.equal(true);
+      expect(err instanceof Error).toBe(true);
       done();
     });
   });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepack": "npm run build",
     "lint": "eslint lib test",
     "lint-prettier": "prettier -l '{lib,test}/**/*.js'",
-    "unit": "jest --verbose",
+    "unit": "jest --verbose lib",
     "test": "npm run unit && npm run lint && npm run lint-prettier",
     "build": "mkdir -p es5/ && babel --out-dir es5 lib"
   },
@@ -27,7 +27,6 @@
     "babel-plugin-syntax-async-functions": "6.13.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.24.0",
     "babel-register": "6.24.0",
-    "chai": "4.0.2",
     "compressjs": "1.0.3",
     "eslint": "3.19.0",
     "eslint-config-airbnb": "15.0.1",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "module": "lib",
   "scripts": {
     "prepack": "npm run build",
-    "lint": "eslint lib test",
-    "lint-prettier": "prettier -l '{lib,test}/**/*.js'",
+    "lint": "eslint lib",
+    "lint-prettier": "prettier -l 'lib/**/*.js'",
     "unit": "jest --verbose lib",
     "test": "npm run unit && npm run lint && npm run lint-prettier",
     "build": "mkdir -p es5/ && babel --out-dir es5 lib"

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,10 +204,6 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assertion-error@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -749,17 +745,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-chai@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.0.2.tgz#2f7327c4de6f385dd7787999e2ab02697a32b83b"
-  dependencies:
-    assertion-error "^1.0.1"
-    check-error "^1.0.1"
-    deep-eql "^2.0.1"
-    get-func-name "^2.0.0"
-    pathval "^1.0.0"
-    type-detect "^4.0.0"
-
 chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -777,10 +762,6 @@ chalk@^2.0.0, chalk@^2.0.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-check-error@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 chokidar@^1.6.1:
   version "1.7.0"
@@ -1017,12 +998,6 @@ decamelize@^1.1.1:
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-
-deep-eql@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-2.0.2.tgz#b1bac06e56f0a76777686d50c9feb75c2ed7679a"
-  dependencies:
-    type-detect "^3.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1702,10 +1677,6 @@ generate-object-property@^1.1.0:
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
-
-get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -3268,10 +3239,6 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-pathval@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -4147,14 +4114,6 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
-
-type-detect@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-3.0.0.tgz#46d0cc8553abb7b13a352b0d6dea2fd58f2d9b55"
-
-type-detect@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
I just followed the guide on https://jestjs.io/docs/en/migration-guide; namely by running `jest-codemods`. No further changes were required.

Changed package.json so that `yarn test` doesn't run an extra copy of the tests when you've run `yarn build` first to produce the `es5` directory.

Motivation: less complexity; jest has some nice helpers like `toMatchObject`.

Test plan: is tests :)