### PR TITLE
Allow multiple reads in browser

### DIFF
--- a/src/BagReader.js
+++ b/src/BagReader.js
@@ -238,10 +238,11 @@ export default class BagReader {
     // if we're reading the same chunk a second time return the cached version
     // to avoid doing decompression on the same chunk multiple times which is
     // expensive
-    if (chunkInfo === this._lastChunkInfo) {
+    if (chunkInfo === this._lastChunkInfo && this._lastReadResult) {
       // always callback async, even if we have the result
       // https://oren.github.io/blog/zalgo.html
-      return setImmediate(() => callback(null, this._lastReadResult));
+      const lastReadResult = this._lastReadResult;
+      return setImmediate(() => callback(null, lastReadResult));
     }
     this._lastChunkInfo = chunkInfo;
     const { nextChunk } = chunkInfo;

--- a/src/BagReader.js
+++ b/src/BagReader.js
@@ -244,7 +244,6 @@ export default class BagReader {
       const lastReadResult = this._lastReadResult;
       return setImmediate(() => callback(null, lastReadResult));
     }
-    this._lastChunkInfo = chunkInfo;
     const { nextChunk } = chunkInfo;
 
     const readLength = nextChunk
@@ -273,6 +272,7 @@ export default class BagReader {
         IndexData
       );
 
+      this._lastChunkInfo = chunkInfo;
       this._lastReadResult = { chunk, indices };
       return callback(null, this._lastReadResult);
     });

--- a/src/bag.test.js
+++ b/src/bag.test.js
@@ -129,6 +129,20 @@ describe("rosbag - high-level api", () => {
     expect(messages[0].message).toMatchSnapshot();
   });
 
+  it("can read bag twice at once", async () => {
+    const bag = await Bag.open(getFixture());
+    const messages1 = [];
+    const messages2 = [];
+    const readPromise1 = bag.readMessages({ topics: ["/tf"] }, (msg) => {
+      messages1.push(msg);
+    });
+    const readPromise2 = bag.readMessages({ topics: ["/tf"] }, (msg) => {
+      messages2.push(msg);
+    });
+    await Promise.all([readPromise1, readPromise2]);
+    expect(messages1).toEqual(messages2);
+  });
+
   it("reads poses", async () => {
     const opts = { topics: ["/turtle1/cmd_vel"] };
     const messages = await fullyReadBag(FILENAME, opts);

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -16,22 +16,16 @@ import BagReader from "../BagReader";
 export class Reader {
   _blob: Blob;
   _size: number;
-  _fileReader: FileReader;
 
   constructor(blob: Blob) {
     this._blob = blob;
     this._size = blob.size;
-    this._fileReader = new FileReader();
   }
 
   // read length (bytes) starting from offset (bytes)
   // callback(err, buffer)
   read(offset: number, length: number, cb: Callback<Buffer>) {
-    const reader = this._fileReader;
-    if (reader.onload) {
-      return cb(new Error("Bag reader is already reading"));
-    }
-
+    const reader = new FileReader();
     reader.onload = function() {
       // $FlowFixMe - flow doesn't allow null
       reader.onload = null;


### PR DESCRIPTION
You cannot read multiple times from the same file reader at once; however, there is nothing in the spec disallowing multiple separate FileReaders from reading from the same file at the same time.

This makes it possible to read several separate chunks or ranges from a bag simultaneously in the browser.

Test plan: Updated tests.  Tested in browser.