### PR TITLE
Set global object in worker

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,9 +29,9 @@ module.exports = {
     path: path.resolve(__dirname, `dist/${target}`),
     library: "rosbag",
     libraryTarget: "umd",
+    // https://github.com/webpack/webpack/issues/6525#issuecomment-417580843
     globalObject: "typeof self !== 'undefined' ? self : this",
   },
   target,
-  // https://github.com/webpack/webpack/issues/6525#issuecomment-417580843
   externals: target === "node" ? [nodeExternals()] : undefined,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,5 +32,6 @@ module.exports = {
     globalObject: "typeof self !== 'undefined' ? self : this",
   },
   target,
+  // https://github.com/webpack/webpack/issues/6525#issuecomment-417580843
   externals: target === "node" ? [nodeExternals()] : undefined,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+// @flow
 // Copyright (c) 2018-present, GM Cruise LLC
 
 // This source code is licensed under the Apache License, Version 2.0,
@@ -7,7 +8,7 @@
 const path = require("path");
 const nodeExternals = require("webpack-node-externals");
 
-const target = process.env.ROSBAG_TARGET;
+const target = process.env.ROSBAG_TARGET || "";
 
 module.exports = {
   entry: `./src/${target}/index.js`,
@@ -28,6 +29,7 @@ module.exports = {
     path: path.resolve(__dirname, `dist/${target}`),
     library: "rosbag",
     libraryTarget: "umd",
+    globalObject: "typeof self !== 'undefined' ? self : this",
   },
   target,
   externals: target === "node" ? [nodeExternals()] : undefined,


### PR DESCRIPTION
When trying to use this in a webworker I was receiving the error `window is not defined.` Using [this approach](https://github.com/webpack/webpack/issues/6525#issuecomment-417580843) to set the global object.  I tested this in the browser main thread, worker, and in node & everything is working now.

Will need to release a new patch version for this.