### PR TITLE
Fix Bag#startTime/endTime not always being present

### DIFF
--- a/src/bag.js
+++ b/src/bag.js
@@ -34,8 +34,8 @@ export default class Bag {
   header: BagHeader;
   connections: { [conn: number]: Connection };
   chunkInfos: ChunkInfo[];
-  startTime?: Time;
-  endTime?: Time;
+  startTime: ?Time;
+  endTime: ?Time;
 
   // you can optionally create a bag manually passing in a bagReader instance
   constructor(bagReader: BagReader) {

--- a/src/bag.js
+++ b/src/bag.js
@@ -34,8 +34,8 @@ export default class Bag {
   header: BagHeader;
   connections: { [conn: number]: Connection };
   chunkInfos: ChunkInfo[];
-  startTime: Time;
-  endTime: Time;
+  startTime?: Time;
+  endTime?: Time;
 
   // you can optionally create a bag manually passing in a bagReader instance
   constructor(bagReader: BagReader) {


### PR DESCRIPTION
These instance variable Flowtypes are a bit funky anyway, since they're
only present after calling `Bag#open()`, not on construction, but I think
for our purposes that's generally okay. But startTime/endTime can not
get set at all even after calling `Bag#open()`, i.e. when chunkCount is
zero.