### PR TITLE
Improve TimeUtil.add

### DIFF
--- a/src/TimeUtil.test.js
+++ b/src/TimeUtil.test.js
@@ -76,6 +76,9 @@ describe("TimeUtil", () => {
     testAddition({ sec: 1, nsec: 0 }, { sec: 0, nsec: -1e9 }, { sec: 0, nsec: 0 });
     testAddition({ sec: 3, nsec: 1 }, { sec: 1, nsec: -2 }, { sec: 3, nsec: 1e9 - 1 });
     testAddition({ sec: 3, nsec: 0 }, { sec: 0, nsec: -(2 * 1e9) + 1 }, { sec: 1, nsec: 1 });
+    testAddition({ sec: 10, nsec: 0 }, { sec: 10, nsec: 10 * 1e9 }, { sec: 30, nsec: 0 });
+    testAddition({ sec: 10, nsec: 0 }, { sec: 10, nsec: -10 * 1e9 }, { sec: 10, nsec: 0 });
+    testAddition({ sec: 0, nsec: 0 }, { sec: 10, nsec: -10 * 1e9 }, { sec: 0, nsec: 0 });
   });
 
   it("throws when addition results in negative time", () => {

--- a/src/TimeUtil.test.js
+++ b/src/TimeUtil.test.js
@@ -59,10 +59,27 @@ describe("TimeUtil", () => {
     expect(TimeUtil.areSame(min, oneNano)).toBe(false);
   });
 
+  const testAddition = (left, right, expected) => {
+    expect(TimeUtil.add(left, right)).toEqual(expected);
+    expect(TimeUtil.add(right, left)).toEqual(expected);
+  };
+
   it("can add two times together", () => {
-    expect(TimeUtil.add({ sec: 0, nsec: 0 }, { sec: 0, nsec: 0 })).toEqual({ sec: 0, nsec: 0 });
-    expect(TimeUtil.add({ sec: 1, nsec: 100 }, { sec: 2, nsec: 200 })).toEqual({ sec: 3, nsec: 300 });
-    expect(TimeUtil.add({ sec: 0, nsec: 1e9 - 1 }, { sec: 0, nsec: 1 })).toEqual({ sec: 1, nsec: 0 });
-    expect(TimeUtil.add({ sec: 0, nsec: 1e9 - 1 }, { sec: 0, nsec: 101 })).toEqual({ sec: 1, nsec: 100 });
+    testAddition({ sec: 0, nsec: 0 }, { sec: 0, nsec: 0 }, { sec: 0, nsec: 0 });
+    testAddition({ sec: 1, nsec: 100 }, { sec: 2, nsec: 200 }, { sec: 3, nsec: 300 });
+    testAddition({ sec: 0, nsec: 1e9 - 1 }, { sec: 0, nsec: 1 }, { sec: 1, nsec: 0 });
+    testAddition({ sec: 0, nsec: 1e9 - 1 }, { sec: 0, nsec: 101 }, { sec: 1, nsec: 100 });
+    testAddition({ sec: 3, nsec: 0 }, { sec: 0, nsec: 2 * -1e9 }, { sec: 1, nsec: 0 });
+    testAddition({ sec: 1, nsec: 1 }, { sec: 0, nsec: -2 }, { sec: 0, nsec: 1e9 - 1 });
+    testAddition({ sec: 1, nsec: 1 }, { sec: 0, nsec: -2 }, { sec: 0, nsec: 1e9 - 1 });
+    testAddition({ sec: 3, nsec: 1 }, { sec: -2, nsec: -2 }, { sec: 0, nsec: 1e9 - 1 });
+    testAddition({ sec: 1, nsec: 0 }, { sec: 0, nsec: -1e9 }, { sec: 0, nsec: 0 });
+    testAddition({ sec: 3, nsec: 1 }, { sec: 1, nsec: -2 }, { sec: 3, nsec: 1e9 - 1 });
+    testAddition({ sec: 3, nsec: 0 }, { sec: 0, nsec: -(2 * 1e9) + 1 }, { sec: 1, nsec: 1 });
+  });
+
+  it("throws when addition results in negative time", () => {
+    expect(() => TimeUtil.add({ sec: 0, nsec: 0 }, { sec: -1, nsec: 0 })).toThrow();
+    expect(() => TimeUtil.add({ sec: 0, nsec: 0 }, { sec: 0, nsec: -1 })).toThrow();
   });
 });


### PR DESCRIPTION
Previously calling `TimeUtil.add` with negative values in either `sec` or `nsec` resulted in undefined-like behavior, producing invalid, negative values in the result without taking into consideration rounding of nsecs to secs.  This change allows for adding a negative time (duration) value to an existing time to produce a new adjusted time with the negative values properly subtracted.  If the resulting time ends up in a negative value, we now throw an exception instead of returning an invalid time value.

Test plan: updated unit tests

Semver impact: this requires a *patch* version bump; we're fixing previously broken behavior.  No new APIs are being added and no existing APIs are being removed.