### PR TITLE
Export `Filelike` and `Callback` types

### DIFF
--- a/src/BagReader.js
+++ b/src/BagReader.js
@@ -6,7 +6,7 @@
 
 // @flow
 
-import type { Time, Callback } from "./types";
+import type { Time, Callback, Filelike } from "./types";
 
 import { parseHeader } from "./header";
 import nmerge from "./nmerge";
@@ -16,11 +16,6 @@ import * as TimeUtil from "./TimeUtil";
 interface ChunkReadResult {
   chunk: Chunk;
   indices: IndexData[];
-}
-
-interface Filelike {
-  read(offset: number, length: number, callback: Callback<Buffer>): void;
-  size(): number;
 }
 
 export type Decompress = {

--- a/src/index.js
+++ b/src/index.js
@@ -12,5 +12,5 @@ export * from "./bag";
 export * from "./BagReader";
 export * from "./MessageReader";
 export * from "./parseMessageDefinition";
-export { Time } from "./types";
+export * from "./types";
 export { TimeUtil };

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -86,6 +86,6 @@ const open = async (filename: File | string) => {
 };
 Bag.open = open;
 
-export { Time } from "../types";
+export * from "../types";
 export { TimeUtil, BagReader, MessageReader, open, parseMessageDefinition, rosPrimitiveTypes };
 export default Bag;

--- a/src/types.js
+++ b/src/types.js
@@ -17,3 +17,8 @@ export interface Time {
   // additional nanoseconds past the sec value
   nsec: number;
 }
+
+export interface Filelike {
+  read(offset: number, length: number, callback: Callback<Buffer>): void;
+  size(): number;
+}

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -61,6 +61,6 @@ const open = async (file: File | string) => {
 };
 Bag.open = open;
 
-export { Time } from "../types";
+export * from "../types";
 export { TimeUtil, BagReader, MessageReader, open, parseMessageDefinition, rosPrimitiveTypes };
 export default Bag;


### PR DESCRIPTION
These are useful when passing your own `Filelike` into a `BagReader`.

Test plan: tried it out with an actual script that uses these types.