### PR TITLE
Use cross-env package to support building on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "lint": "yarn run flow && eslint src && prettier -l 'src/**/*.js'",
     "test": "yarn run jest --verbose && yarn run lint",
     "clean": "rm -rf build dist",
-    "build": "yarn run clean && mkdir -p dist/ && yarn run flow && yarn run build-node && yarn run build-web && yarn run flow-copy-source src dist",
-    "build-node": "ROSBAG_TARGET=node webpack --mode development",
-    "build-web": "ROSBAG_TARGET=web webpack --mode development"
+    "build": "yarn run clean && mkdir -p dist && yarn run flow && yarn run build-node && yarn run build-web && yarn run flow-copy-source src dist",
+    "build-node": "cross-env ROSBAG_TARGET=node webpack --mode development",
+    "build-web": "cross-env ROSBAG_TARGET=web webpack --mode development"
   },
   "devDependencies": {
     "@babel/cli": "7.1.2",
@@ -40,6 +40,7 @@
     "babel-jest": "23.6.0",
     "babel-loader": "8.0.4",
     "compressjs": "1.0.3",
+    "cross-env": "5.2.0",
     "eslint": "5.7.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,6 +1954,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3720,7 +3728,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
I happened to be using Windows to build a local version of the library so this PR makes two changes to support that:

- Add [cross-env](http://npmjs.com/package/cross-env) package to support environment variables on Windows.
- Remove the slash after "dist" in `mkdir -p dist/` because it was causing the command to fail.

I haven't tested this on a unix machine but I believe these changes should be cross compatible and if not would think the CI would fail.

Thanks!