### PR TITLE
Bump version to 2.2.0: Update int53 package to properly bubble up errors to rosbag.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "buffer": "5.2.1",
     "heap": "0.2.6",
-    "int53": "0.2.4"
+    "int53": "1.0.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/BagReader.js
+++ b/src/BagReader.js
@@ -75,8 +75,12 @@ export default class BagReader {
         if (read < headerLength + 8) {
           return callback(new Error(`Record at position ${HEADER_OFFSET} header too large: ${headerLength}.`));
         }
-        const header = this.readRecordFromBuffer(buffer, HEADER_OFFSET, BagHeader);
-        return callback(null, header);
+        try {
+          const header = this.readRecordFromBuffer(buffer, HEADER_OFFSET, BagHeader);
+          return callback(null, header);
+        } catch (e) {
+          return callback(new Error(`Could not read header from rosbag file buffer - ${e.message}`));
+        }
       });
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3426,10 +3426,10 @@ inquirer@^6.1.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-int53@0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/int53/-/int53-0.2.4.tgz#5ed8d7aad6c5c6567cae69aa7ffc4a109ee80f86"
-  integrity sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y=
+int53@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/int53/-/int53-1.0.0.tgz#65eef2b8e25df0d8d137520f31c47da67c97aaa1"
+  integrity sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==
 
 interpret@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
**SUMMARY:**
- Earlier version of `int53` package merely invoked `console.assert()` for certain errors, instead of actually throwing errors
- That meant `int53` errors never bubbled up properly to `rosbag.js`, and instead printed out silently to the console
- By updating `int53`, we ensure that errors are actually thrown to be caught by `rosbag.js`
- This PR also adds a try/catch to handle possible errors being thrown by `int53`