### PR TITLE
add support for python bool values

### DIFF
--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -112,6 +112,9 @@ const buildType = (lines: string[]): RosMsgDefinition => {
       }
       let value: any = matches[2];
       if (type !== "string") {
+        // handle special case of python bool values
+        value = value.replace(/True/gi, "true");
+        value = value.replace(/False/gi, "false");
         try {
           value = JSON.parse(value.replace(/\s*#.*/g, ""));
         } catch (error) {

--- a/src/parseMessageDefinition.test.js
+++ b/src/parseMessageDefinition.test.js
@@ -263,4 +263,31 @@ describe("parseMessageDefinition", () => {
       },
     ]);
   });
+
+  it("works with python boolean values", () => {
+    const messageDefinition = `
+      bool Alive=True
+      bool Dead=False
+    `;
+    const types = parseMessageDefinition(messageDefinition);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            name: "Alive",
+            type: "bool",
+            isConstant: true,
+            value: true,
+          },
+          {
+            name: "Dead",
+            type: "bool",
+            isConstant: true,
+            value: false,
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
This PR converts possible python bool values to a JSON compatible bool values. Check #56 
If not converted, parsing of these values fails for JSON.parse() function.

Fixes #56
