### PR TITLE
Add “freeze” option for building immutable messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,15 @@ const bagOptions = {
   decompress?: {|
     bz2?: (buffer: Buffer, uncompressedByteLength: number) => Buffer,
     lz4?: (buffer: Buffer, uncompressedByteLength: number) => Buffer,
-  |}
+  |},
 
   // by default the individual parsed binary messages will be parsed based on their [ROS message definition](http://wiki.ros.org/msg)
   // if you set noParse to true the read operation will skip the message parsing step
-  noParse?: boolean
+  noParse?: boolean,
+
+  // Whether the resulting messages should be deeply frozen using Object.freeze(). (default: false)
+  // Useful to make sure your code or libraries doesn't accidentally mutate bag messages.
+  freeze?: boolean,
 }
 ```
 

--- a/src/ReadResult.js
+++ b/src/ReadResult.js
@@ -18,7 +18,15 @@ export default class ReadResult<T> {
   chunkOffset: number;
   totalChunks: number;
 
-  constructor(topic: string, message: T, timestamp: Time, data: Buffer, chunkOffset: number, totalChunks: number) {
+  constructor(
+    topic: string,
+    message: T,
+    timestamp: Time,
+    data: Buffer,
+    chunkOffset: number,
+    totalChunks: number,
+    freeze?: ?boolean
+  ) {
     // string: the topic the message was on
     this.topic = topic;
 
@@ -36,5 +44,10 @@ export default class ReadResult<T> {
 
     // the total number of chunks in the read operation
     this.totalChunks = totalChunks;
+
+    if (freeze) {
+      Object.freeze(timestamp);
+      Object.freeze(this);
+    }
   }
 }

--- a/src/bag.js
+++ b/src/bag.js
@@ -19,6 +19,7 @@ export type ReadOptions = {|
   topics?: string[],
   startTime?: Time,
   endTime?: Time,
+  freeze?: ?boolean,
 |};
 
 // the high level rosbag interface
@@ -102,10 +103,11 @@ export default class Bag {
       let message = null;
       if (!opts.noParse) {
         // lazily create a reader for this connection if it doesn't exist
-        connection.reader = connection.reader || new MessageReader(connection.messageDefinition);
+        connection.reader =
+          connection.reader || new MessageReader(connection.messageDefinition, { freeze: opts.freeze });
         message = connection.reader.readMessage(data);
       }
-      return new ReadResult(topic, message, timestamp, data, chunkOffset, chunkInfos.length);
+      return new ReadResult(topic, message, timestamp, data, chunkOffset, chunkInfos.length, opts.freeze);
     }
 
     for (let i = 0; i < chunkInfos.length; i++) {


### PR DESCRIPTION
This way we can prevent our code or libraries from mutating raw
messages.

Initially I tried to do this on existing messages using the
`simple-deep-freeze` library, but that only works on “simple” objects
(without a custom prototype), but we want to keep custom prototypes
since they look better in the browser console, and they are necessary if
in the future we build lazy parsing. So just freezing them within
rosbag.js is better since that way we have more control over exactly how
the freezing works.

Test plan: added a bunch of tests.