### PR TITLE
Update Readme with correct example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,23 @@ Here is an example of reading messages from a rosbag in node.js:
 ```js
 const { open } = require('rosbag');
 
-// open a new bag at a given file location:
-const bag = await open('../path/to/ros.bag');
+async function logMessagesFromFooBar() {
+  // open a new bag at a given file location:
+  const bag = await open('../path/to/ros.bag');
 
-// read all messages from both the '/foo' and '/bar' topics:
-await bag.readMessages({ topics: ['/foo', '/bar'] }, (result) => {
-  // topic is the topic the data record was in
-  // in this case it will be either '/foo' or '/bar'
-  console.log(result.topic);
+  // read all messages from both the '/foo' and '/bar' topics:
+  await bag.readMessages({ topics: ['/foo', '/bar'] }, (result) => {
+    // topic is the topic the data record was in
+    // in this case it will be either '/foo' or '/bar'
+    console.log(result.topic);
 
-  // message is the parsed payload
-  // this payload will likely differ based on the topic
-  console.log(result.message);
-});
+    // message is the parsed payload
+    // this payload will likely differ based on the topic
+    console.log(result.message);
+  });
+}
+
+logMessagesFromFooBar();
 ```
 
 ## API


### PR DESCRIPTION
With the current example in the readme you get a syntax error in Node.js

```
const bag = await open('../path/to/ros.bag');
            ^^^^^

SyntaxError: await is only valid in async function
    at new Script (vm.js:80:7)
    at createScript (vm.js:274:10)
    at Object.runInThisContext (vm.js:326:10)
    at Module._compile (internal/modules/cjs/loader.js:664:28)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
```

Edited it so that you don't get the syntax error