### PR TITLE
Actually expose the fields methods as a public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -8,7 +8,14 @@
 
 import { Buffer } from "buffer";
 import * as fs from "fs";
-import { MessageReader, parseMessageDefinition, rosPrimitiveTypes, TimeUtil } from "../index";
+import {
+  MessageReader,
+  parseMessageDefinition,
+  rosPrimitiveTypes,
+  TimeUtil,
+  extractFields,
+  extractTime,
+} from "../index";
 import type { Callback } from "../types";
 import Bag from "../bag";
 import BagReader from "../BagReader";
@@ -87,5 +94,14 @@ const open = async (filename: File | string) => {
 Bag.open = open;
 
 export * from "../types";
-export { TimeUtil, BagReader, MessageReader, open, parseMessageDefinition, rosPrimitiveTypes };
+export {
+  TimeUtil,
+  BagReader,
+  MessageReader,
+  open,
+  parseMessageDefinition,
+  rosPrimitiveTypes,
+  extractFields,
+  extractTime,
+};
 export default Bag;

--- a/src/node/index.test.js
+++ b/src/node/index.test.js
@@ -10,18 +10,25 @@ import assert from "assert";
 import path from "path";
 import fs from "fs";
 
-import { Reader } from ".";
+import { Reader, extractFields, extractTime } from ".";
 
-describe("Reader", () => {
-  const fixture = path.join(__dirname, "..", "..", "fixtures", "asci-file.txt");
+describe("node entrypoint", () => {
+  describe("Reader", () => {
+    const fixture = path.join(__dirname, "..", "..", "fixtures", "asci-file.txt");
 
-  it("should read bytes from a file", (done) => {
-    const reader = new Reader(fixture);
-    reader.read(5, 10, (err: Error | null, buff: any) => {
-      assert(!err);
-      assert.equal(reader.size(), fs.statSync(fixture).size);
-      assert.equal("6789012345", buff.toString());
-      reader.close(done);
+    it("should read bytes from a file", (done) => {
+      const reader = new Reader(fixture);
+      reader.read(5, 10, (err: Error | null, buff: any) => {
+        assert(!err);
+        assert.equal(reader.size(), fs.statSync(fixture).size);
+        assert.equal("6789012345", buff.toString());
+        reader.close(done);
+      });
     });
+  });
+
+  it("exposes other methods", () => {
+    expect(extractFields).toBeDefined();
+    expect(extractTime).toBeDefined();
   });
 });

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -7,7 +7,14 @@
 // @flow
 
 import { Buffer } from "buffer";
-import { MessageReader, parseMessageDefinition, rosPrimitiveTypes, TimeUtil } from "../index";
+import {
+  MessageReader,
+  parseMessageDefinition,
+  rosPrimitiveTypes,
+  TimeUtil,
+  extractFields,
+  extractTime,
+} from "../index";
 import { type Callback } from "../types";
 import Bag from "../bag";
 import BagReader from "../BagReader";
@@ -62,5 +69,14 @@ const open = async (file: File | string) => {
 Bag.open = open;
 
 export * from "../types";
-export { TimeUtil, BagReader, MessageReader, open, parseMessageDefinition, rosPrimitiveTypes };
+export {
+  TimeUtil,
+  BagReader,
+  MessageReader,
+  open,
+  parseMessageDefinition,
+  rosPrimitiveTypes,
+  extractFields,
+  extractTime,
+};
 export default Bag;

--- a/src/web/index.test.js
+++ b/src/web/index.test.js
@@ -6,7 +6,7 @@
 
 // @flow
 
-import { Reader } from ".";
+import { Reader, extractFields, extractTime } from ".";
 
 describe("browser reader", () => {
   it("works in node", (done) => {
@@ -59,5 +59,10 @@ describe("browser reader", () => {
       expect(err.message).toBe("fake error");
       done();
     });
+  });
+
+  it("exposes other methods", () => {
+    expect(extractFields).toBeDefined();
+    expect(extractTime).toBeDefined();
   });
 });


### PR DESCRIPTION
I clearly wasn’t careful enough in PR #64. This should properly expose
these methods.