### PR TITLE
Do not inline everything in generated parse code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {


### PR DESCRIPTION
Instead of inlining every field for every submessage recursively, we
should instead use functions for distinct message types.

For types like

    A { B b1, b2 };
    B { C c1, c2 };
    ...
    N { int dummy };

the size of the generated code is O(N) rather than O(2^N), and the size
of the largest function body is O(1) instead of O(2^N). This can make a
large performance difference for very large message definition DAGs in
Chrome (which will not optimise functions with code size larger than
128KB.) This results in a measured playback speedup of about 5% for
some bags in webviz.

(One possible downside, the maximum stack depth is now linear, not
constant. Probably not an issue in practice?)

The total number of function calls is not increased by this change, and
the the removal of the `this.field_X = undefined;` logic doesn't seem to
hurt the object layout.

As a nice upside, this represents a nice simplification of both the
generating and generated code.

Test plan: No change in functionality. Covered by existing tests.