### PR TITLE
Use #pragma comment to specify when incoming ROS message field should be parsed as JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "prepack": "yarn run build",
     "lint": "yarn run flow && eslint src && prettier -l 'src/**/*.js'",
+    "lint-fix": "prettier -l --write 'src/**/*.js'",
     "test": "yarn run jest --verbose && yarn run lint",
     "clean": "rm -rf build dist",
     "build": "yarn run clean && mkdir -p dist && yarn run flow && yarn run build-node && yarn run build-web && yarn run flow-copy-source src dist",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "prepack": "yarn run build",
     "lint": "yarn run flow && eslint src && prettier -l 'src/**/*.js'",
-    "lint-fix": "prettier -l --write 'src/**/*.js'",
+    "lint:fix": "eslint --fix src && prettier --write -l 'src/**/*.js'",
     "test": "yarn run jest --verbose && yarn run lint",
     "clean": "rm -rf build dist",
     "build": "yarn run clean && mkdir -p dist && yarn run flow && yarn run build-node && yarn run build-web && yarn run flow-copy-source src dist",

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -48,14 +48,28 @@ class StandardTypeReader {
     // in those cases revert to a slower itterative string building approach
     if (codePoints.length < 1000) {
       const resultString = String.fromCharCode.apply(null, codePoints);
-      return isJson ? JSON.parse(resultString) : resultString;
+      if (isJson) {
+        try {
+          return JSON.parse(resultString);
+        } catch {
+          return `Could not parse ${resultString}`;
+        }
+      }
+      return resultString;
     }
 
     let data = "";
     for (let i = 0; i < len; i++) {
       data += String.fromCharCode(codePoints[i]);
     }
-    return isJson ? JSON.parse(data) : data;
+    if (isJson) {
+      try {
+        return JSON.parse(data);
+      } catch {
+        return `Could not parse ${data}`;
+      }
+    }
+    return data;
   }
 
   bool() {

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -257,7 +257,7 @@ const createParser = (types: RosMsgDefinition[], freeze: boolean) => {
     throw e;
   }
 
-  return function (buffer: Buffer) {
+  return function(buffer: Buffer) {
     const reader = new StandardTypeReader(buffer);
     return _read(reader);
   };

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -45,31 +45,26 @@ class StandardTypeReader {
     this.offset += len;
     // if the string is relatively short we can use apply
     // but very long strings can cause a stack overflow due to too many arguments
-    // in those cases revert to a slower itterative string building approach
+    // in those cases revert to a slower iterative string building approach
+    let resultString = "";
     if (codePoints.length < 1000) {
-      const resultString = String.fromCharCode.apply(null, codePoints);
-      if (isJson) {
-        try {
-          return JSON.parse(resultString);
-        } catch {
-          return `Could not parse ${resultString}`;
-        }
-      }
-      return resultString;
+      resultString = String.fromCharCode.apply(null, codePoints);
     }
 
-    let data = "";
-    for (let i = 0; i < len; i++) {
-      data += String.fromCharCode(codePoints[i]);
-    }
-    if (isJson) {
-      try {
-        return JSON.parse(data);
-      } catch {
-        return `Could not parse ${data}`;
+    if (!resultString.length) {
+      for (let i = 0; i < len; i++) {
+        resultString += String.fromCharCode(codePoints[i]);
       }
     }
-    return data;
+
+    if (isJson) {
+      try {
+        return JSON.parse(resultString);
+      } catch {
+        return `Could not parse ${resultString}`;
+      }
+    }
+    return resultString;
   }
 
   bool() {

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -247,7 +247,7 @@ const createParser = (types: RosMsgDefinition[], freeze: boolean) => {
     throw e;
   }
 
-  return function (buffer: Buffer) {
+  return function(buffer: Buffer) {
     const reader = new StandardTypeReader(buffer);
     return _read(reader);
   };

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -44,7 +44,7 @@ class StandardTypeReader {
     try {
       return JSON.parse(resultString);
     } catch {
-      return { err: `Could not parse ${resultString}` };
+      return `Could not parse ${resultString}`;
     }
   }
 

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -55,17 +55,15 @@ class StandardTypeReader {
     // if the string is relatively short we can use apply
     // but very long strings can cause a stack overflow due to too many arguments
     // in those cases revert to a slower iterative string building approach
-    let resultString = "";
     if (codePoints.length < 1000) {
-      resultString = String.fromCharCode.apply(null, codePoints);
+      return String.fromCharCode.apply(null, codePoints);
     }
 
-    if (!resultString.length) {
-      for (let i = 0; i < len; i++) {
-        resultString += String.fromCharCode(codePoints[i]);
-      }
+    let data = "";
+    for (let i = 0; i < len; i++) {
+      data += String.fromCharCode(codePoints[i]);
     }
-    return resultString;
+    return data;
   }
 
   bool() {

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -39,7 +39,7 @@ class StandardTypeReader {
     this.view = new DataView(buffer.buffer, buffer.byteOffset);
   }
 
-  json(): { [key: string]: any } {
+  json(): mixed {
     const resultString = this.string();
     try {
       return JSON.parse(resultString);

--- a/src/MessageReader.test.js
+++ b/src/MessageReader.test.js
@@ -49,7 +49,7 @@ describe("MessageReader", () => {
       const reader = new MessageReader("#pragma rosbag_parse_json\nstring dummy");
       const buff = getStringBuffer('{"foo":123,"bar":{"nestedFoo":456}}');
       expect(reader.readMessage(buff)).toEqual({
-        dummy: { foo: 123, bar: { nestedFoo: 456 } }
+        dummy: { foo: 123, bar: { nestedFoo: 456 } },
       });
     });
 

--- a/src/MessageReader.test.js
+++ b/src/MessageReader.test.js
@@ -51,6 +51,16 @@ describe("MessageReader", () => {
       expect(reader.readMessage(buff)).toEqual({
         dummy: { foo: 123, bar: { nestedFoo: 456 } },
       });
+
+      const readerWithSpaces = new MessageReader(" #pragma rosbag_parse_json  \n  string dummy");
+      expect(readerWithSpaces.readMessage(buff)).toEqual({
+        dummy: { foo: 123, bar: { nestedFoo: 456 } },
+      });
+
+      const readerWithNewlines = new MessageReader("#pragma rosbag_parse_json\n\n\nstring dummy");
+      expect(readerWithNewlines.readMessage(buff)).toEqual({
+        dummy: { foo: 123, bar: { nestedFoo: 456 } },
+      });
     });
 
     it("parses time", () => {

--- a/src/MessageReader.test.js
+++ b/src/MessageReader.test.js
@@ -45,7 +45,7 @@ describe("MessageReader", () => {
       });
     });
 
-    it.only("parses JSON", () => {
+    it("parses JSON", () => {
       const reader = new MessageReader("#pragma rosbag_parse_json\nstring dummy");
       const buff = getStringBuffer('{"foo":123,"bar":{"nestedFoo":456}}');
       expect(reader.readMessage(buff)).toEqual({

--- a/src/MessageReader.test.js
+++ b/src/MessageReader.test.js
@@ -45,6 +45,14 @@ describe("MessageReader", () => {
       });
     });
 
+    it.only("parses JSON", () => {
+      const reader = new MessageReader("#pragma rosbag_parse_json\nstring dummy");
+      const buff = getStringBuffer('{"foo":123,"bar":{"nestedFoo":456}}');
+      expect(reader.readMessage(buff)).toEqual({
+        dummy: { foo: 123, bar: { nestedFoo: 456 } }
+      });
+    });
+
     it("parses time", () => {
       const reader = new MessageReader("time right_now");
       const buff = new Buffer(8);

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -55,39 +55,39 @@ function newDefinition(type: string, name: string, isJson: boolean): RosMsgField
     name,
     isArray: false,
     isComplex: !rosPrimitiveTypes.has(normalizedType),
-    ...(isJson ? { isJson } : {})
+    ...(isJson ? { isJson } : {}),
   };
 }
 
 export type RosMsgField =
   | {|
-  type: string,
-    name: string,
-      isConstant ?: boolean,
-      isComplex ?: boolean,
-      isJson ?: boolean,
-      value ?: mixed,
-      isArray ?: false,
-      arrayLength ?: void,
+      type: string,
+      name: string,
+      isConstant?: boolean,
+      isComplex?: boolean,
+      isJson?: boolean,
+      value?: mixed,
+      isArray?: false,
+      arrayLength?: void,
     |}
   | {|
-  type: string,
-    name: string,
-      isConstant ?: boolean,
-      isComplex ?: boolean,
-      isJson ?: boolean,
-      value ?: mixed,
+      type: string,
+      name: string,
+      isConstant?: boolean,
+      isComplex?: boolean,
+      isJson?: boolean,
+      value?: mixed,
       isArray: true,
-        arrayLength: ?number,
+      arrayLength: ?number,
     |};
 
 export type RosMsgDefinition = {|
   name?: string,
-    definitions: RosMsgField[],
+  definitions: RosMsgField[],
 |};
 export type NamedRosMsgDefinition = {|
   name: string,
-    definitions: RosMsgField[],
+  definitions: RosMsgField[],
 |};
 
 const buildType = (lines: { isJson: boolean, line: string }[]): RosMsgDefinition => {

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -195,16 +195,12 @@ export function parseMessageDefinition(messageDefinition: string) {
 
   let definitionLines: { isJson: boolean, line: string }[] = [];
   const types: RosMsgDefinition[] = [];
-  const pragmaLineIndices: number[] = [];
+  let nextDefinitionIsJson: boolean = false;
   // group lines into individual definitions
-  allLines.forEach((line, idx) => {
+  allLines.forEach((line) => {
     // ignore comment lines unless they start with #pragma rosbag_parse_json
-    if (line.indexOf("#") === 0) {
-      if (line.indexOf("#pragma rosbag_parse_json") === 0) {
-        pragmaLineIndices.push(idx);
-      } else {
-        return;
-      }
+    if (line.indexOf("#") === 0 && line.indexOf("#pragma rosbag_parse_json") !== 0) {
+      return;
     }
 
     // definitions are split by equal signs
@@ -212,7 +208,12 @@ export function parseMessageDefinition(messageDefinition: string) {
       types.push(buildType(definitionLines));
       definitionLines = [];
     } else {
-      definitionLines.push({ isJson: pragmaLineIndices.includes(idx - 1), line });
+      definitionLines.push({ isJson: nextDefinitionIsJson, line });
+      nextDefinitionIsJson = false;
+    }
+
+    if (line.indexOf("#pragma rosbag_parse_json") === 0) {
+      nextDefinitionIsJson = true;
     }
   });
   types.push(buildType(definitionLines));

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -197,7 +197,8 @@ export function parseMessageDefinition(messageDefinition: string) {
   // group lines into individual definitions
   allLines.forEach((line) => {
     // ignore comment lines unless they start with #pragma rosbag_parse_json
-    if (line.indexOf("#") === 0 && line.indexOf("#pragma rosbag_parse_json") !== 0) {
+    const pragmaCommentIdx = line.indexOf("#pragma rosbag_parse_json");
+    if (line.indexOf("#") === 0 && pragmaCommentIdx !== 0) {
       return;
     }
 
@@ -211,7 +212,7 @@ export function parseMessageDefinition(messageDefinition: string) {
       nextDefinitionIsJson = false;
     }
 
-    if (line.indexOf("#pragma rosbag_parse_json") === 0) {
+    if (pragmaCommentIdx === 0) {
       nextDefinitionIsJson = true;
     }
   });

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -197,23 +197,21 @@ export function parseMessageDefinition(messageDefinition: string) {
   // group lines into individual definitions
   allLines.forEach((line) => {
     // ignore comment lines unless they start with #pragma rosbag_parse_json
-    const pragmaCommentIdx = line.indexOf("#pragma rosbag_parse_json");
-    if (line.indexOf("#") === 0 && pragmaCommentIdx !== 0) {
+    if (line.startsWith("#")) {
+      if (line.startsWith("#pragma rosbag_parse_json")) {
+        nextDefinitionIsJson = true;
+      }
       return;
     }
 
     // definitions are split by equal signs
-    if (line.indexOf("==") === 0) {
+    if (line.startsWith("==")) {
       nextDefinitionIsJson = false;
       types.push(buildType(definitionLines));
       definitionLines = [];
     } else {
       definitionLines.push({ isJson: nextDefinitionIsJson, line });
       nextDefinitionIsJson = false;
-    }
-
-    if (pragmaCommentIdx === 0) {
-      nextDefinitionIsJson = true;
     }
   });
   types.push(buildType(definitionLines));

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -22,6 +22,7 @@ export const rosPrimitiveTypes: Set<string> = new Set([
   "uint64",
   "time",
   "duration",
+  "json",
 ]);
 
 function normalizeType(type: string) {
@@ -48,14 +49,13 @@ function newArrayDefinition(type: string, name: string, arrayLength: ?number): R
     isComplex: !rosPrimitiveTypes.has(normalizedType),
   };
 }
-function newDefinition(type: string, name: string, isJson: boolean): RosMsgField {
+function newDefinition(type: string, name: string): RosMsgField {
   const normalizedType = normalizeType(type);
   return {
     type: normalizedType,
     name,
     isArray: false,
     isComplex: !rosPrimitiveTypes.has(normalizedType),
-    ...(isJson && normalizedType === "string" ? { isJson } : {}),
   };
 }
 
@@ -65,7 +65,6 @@ export type RosMsgField =
       name: string,
       isConstant?: boolean,
       isComplex?: boolean,
-      isJson?: boolean,
       value?: mixed,
       isArray?: false,
       arrayLength?: void,
@@ -75,7 +74,6 @@ export type RosMsgField =
       name: string,
       isConstant?: boolean,
       isComplex?: boolean,
-      isJson?: boolean,
       value?: mixed,
       isArray: true,
       arrayLength: ?number,
@@ -146,7 +144,7 @@ const buildType = (lines: { isJson: boolean, line: string }[]): RosMsgDefinition
       const len = typeSplits[1].replace("]", "");
       definitions.push(newArrayDefinition(baseType, name, len ? parseInt(len, 10) : undefined));
     } else {
-      definitions.push(newDefinition(type, name, isJson));
+      definitions.push(newDefinition(isJson ? "json" : type, name));
     }
   });
   return { name: complexTypeName, definitions };

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -205,6 +205,7 @@ export function parseMessageDefinition(messageDefinition: string) {
 
     // definitions are split by equal signs
     if (line.indexOf("==") === 0) {
+      nextDefinitionIsJson = false;
       types.push(buildType(definitionLines));
       definitionLines = [];
     } else {

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -112,7 +112,7 @@ const buildType = (lines: { isJson: boolean, line: string }[]): RosMsgDefinition
         throw new Error("Malformed line: " + line);
       }
       let value: any = matches[2];
-      if (type !== "string" || isJson) {
+      if (type !== "string") {
         // handle special case of python bool values
         value = value.replace(/True/gi, "true");
         value = value.replace(/False/gi, "false");

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -55,7 +55,7 @@ function newDefinition(type: string, name: string, isJson: boolean): RosMsgField
     name,
     isArray: false,
     isComplex: !rosPrimitiveTypes.has(normalizedType),
-    isJson
+    ...(isJson ? { isJson } : {})
   };
 }
 

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -55,7 +55,7 @@ function newDefinition(type: string, name: string, isJson: boolean): RosMsgField
     name,
     isArray: false,
     isComplex: !rosPrimitiveTypes.has(normalizedType),
-    ...(isJson ? { isJson } : {}),
+    ...(isJson && normalizedType === "string" ? { isJson } : {}),
   };
 }
 


### PR DESCRIPTION
- [x] **Reviewability.** - < 100 LOC
- [x] **Summary.** 
   -  Use `#pragma rosbag_parse_json` comment as a flag for when a specific ROS message field should be parsed into JSON
- [x] **Test plan.** - Added unit test in MessageReader