### PR TITLE
Flow control for async message consumers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.11
+      - image: circleci/node:10.0.0
 
     working_directory: ~/repo
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,31 @@ async function logMessagesFromFooBar() {
 logMessagesFromFooBar();
 ```
 
+If you're dealing with large rosbag files and need flow control to process messages async, use the Async Generator `iterateMessages`.
+
+```js
+const { open } = require('rosbag');
+
+async function readWithAsyncConsumer () {
+  const options = { topics: ['/unicorns'] };
+  const bag = await open("filename.bag");
+  for await (const msg of bag.iterateMessages(options)) {
+    // each message is read separately
+    // respecting async behavior in the for loop
+    await doSomethingAsync(msg);
+  }
+}
+
+readWithAsyncConsumer()
+  .then(() => console.log("DONE"));
+
+```
+
+That way you can also create a readable message stream
+```js
+  require("stream").Readable.from(bag.iterateMessages(options))
+```
+
 ## API
 
 ### Opening a new rosbag reader

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "int53": "1.0.0"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "main": "dist/node",
   "browser": "dist/web",

--- a/src/bag.js
+++ b/src/bag.js
@@ -73,6 +73,12 @@ export default class Bag {
   }
 
   async readMessages(opts: ReadOptions, callback: (msg: ReadResult<any>) => void) {
+    for await (const msg of this.iterateMessages(opts)) {
+      callback(msg);
+    }
+  }
+
+  async *iterateMessages(opts: ReadOptions): AsyncGenerator<ReadResult<any>, void, number> {
     const connections = this.connections;
 
     const startTime = opts.startTime || { sec: 0, nsec: 0 };
@@ -119,7 +125,9 @@ export default class Bag {
         endTime,
         decompress
       );
-      messages.forEach((msg) => callback(parseMsg(msg, i)));
+      for (const msg of messages) {
+        if (yield parseMsg(msg, i)) return;
+      }
     }
   }
 }

--- a/src/bag.test.js
+++ b/src/bag.test.js
@@ -211,6 +211,23 @@ describe("rosbag - high-level api", () => {
     expect(messages).toHaveLength(9);
   });
 
+  it("reads at consumer speed and abort reading on demand", async () => {
+    const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const opts = { topics: ["/tf"] };
+    const bag = await Bag.open(getFixture());
+    const messages = bag.iterateMessages(opts || {});
+    const r1 = await messages.next();
+    expect(r1.value.timestamp.nsec).toBe(56251251);
+    expect(r1.done).toBe(false);
+    await delay(100);
+    const r2 = await messages.next();
+    expect(r2.value.timestamp.nsec).toBe(56262848);
+    expect(r2.done).toBe(false);
+    await delay(100);
+    const r3 = await messages.next(true);
+    expect(r3.done).toBe(true);
+  });
+
   describe("compression", () => {
     it("throws if compression scheme is not registered", async () => {
       let errorThrown = false;


### PR DESCRIPTION
Hi,

first of all thanks for providing rosbag.js it really made my day ☀️ 

I'm dealing with rosbag files that exceed my heap space and want to perform async operations on the messages. 
Since (IMHU) calling `bag.readMessages` provides no means to slow down the producer I have to choose between dropping messages or running out of heap.

As a resolve I added flow control via `bag.iterateMessages`. It does almost exactly the same thing as `bag.readMessages` but it acts as async generator. That means the consumer can (if desired) halt and resume the reading process.
In order to avoid code redundancies and minimise code changes, I rewired `readMessages` to invoke `iterateMessages` maintaining its original behavior.

Documentation and one additional test case is included in this PR.

If I overlooked existing functionality that already provides flow control, please let me know, so that I can use that instead.

I also bumped the node engine version to 10+ because the existing test cases failed at lower versions.

Regards, Marc