### PR TITLE
Add message writer API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 2.5.0
+
+* Added MessageWriter functionality, and deprecated passing the unparsed message definitions direction to MessageReader.
+
 # 1.3.0
 
 * Reorganized the repository, build using webpack, and export Flow type definitions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -264,11 +264,18 @@ const createParser = (types: RosMsgDefinition[], freeze: boolean) => {
 export class MessageReader {
   reader: (buffer: Buffer) => any;
 
-  // takes a multi-line string message definition and returns
+  // takes an object message definition and returns
   // a message reader which can be used to read messages based
   // on the message definition
-  constructor(messageDefinition: string, options: { freeze?: ?boolean } = {}) {
-    const definitions = parseMessageDefinition(messageDefinition);
+  constructor(definitions: RosMsgDefinition[], options: { freeze?: ?boolean } = {}) {
+    let parsedDefinitions = definitions;
+    if (typeof parsedDefinitions === "string") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Passing string message defintions to MessageReader is deprecated. Instead call `parseMessageDefinition` on it and pass in the resulting parsed message definition object."
+      );
+      parsedDefinitions = parseMessageDefinition(parsedDefinitions);
+    }
     this.reader = createParser(definitions, !!options.freeze);
   }
 

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -165,12 +165,12 @@ const findTypeByName = (types: RosMsgDefinition[], name = ""): NamedRosMsgDefini
     return false;
   });
   if (matches.length !== 1) {
-    throw new Error(`Expected 1 top level type definition for '${name}' but found ${matches.length}`);
+    throw new Error(`Expected 1 top level type definition for '${name}' but found ${matches.length}.`);
   }
   return { ...matches[0], name: foundName };
 };
 
-const friendlyName = (name: string) => name.replace("/", "_");
+const friendlyName = (name: string) => name.replace(/\//g, "_");
 
 const createParser = (types: RosMsgDefinition[], freeze: boolean) => {
   const unnamedTypes = types.filter((type) => !type.name);
@@ -251,7 +251,7 @@ const createParser = (types: RosMsgDefinition[], freeze: boolean) => {
   try {
     _read = eval(`(function buildReader() { ${js} })()`);
   } catch (e) {
-    console.error("error building parser:", js); // eslint-disable-line
+    console.error("error building parser:", js); // eslint-disable-line no-console
     throw e;
   }
 

--- a/src/MessageWriter.js
+++ b/src/MessageWriter.js
@@ -191,7 +191,7 @@ const findTypeByName = (types: RosMsgDefinition[], name = ""): NamedRosMsgDefini
   return { ...matches[0], name: foundName };
 };
 
-const friendlyName = (name: string) => name.replace("/", "_");
+const friendlyName = (name: string) => name.replace(/\//g, "_");
 
 function createWriter(types: RosMsgDefinition[]): (message: any) => Buffer {
   const unnamedTypes = types.filter((type) => !type.name);
@@ -276,13 +276,13 @@ function createWriter(types: RosMsgDefinition[]): (message: any) => Buffer {
   try {
     _write = eval(`(function buildWriter() { ${writerJs} })()`);
   } catch (e) {
-    console.error("error building writer:", writerJs); // eslint-disable-line
+    console.error("error building writer:", writerJs); // eslint-disable-line no-console
     throw e;
   }
   try {
     _calculateSize = eval(`(function buildSizeCalculator() { ${calculateSizeJs} })()`);
   } catch (e) {
-    console.error("error building size calculator:", calculateSizeJs); // eslint-disable-line
+    console.error("error building size calculator:", calculateSizeJs); // eslint-disable-line no-console
     throw e;
   }
 
@@ -299,7 +299,7 @@ export class MessageWriter {
   writer: (message: any) => Buffer;
 
   // takes a multi-line string message definition and returns
-  // a message reader which can be used to write messages based
+  // a message writer which can be used to write messages based
   // on the message definition
   constructor(messageDefinition: string) {
     const definitions = parseMessageDefinition(messageDefinition);

--- a/src/MessageWriter.js
+++ b/src/MessageWriter.js
@@ -8,7 +8,7 @@
 
 import int53 from "int53";
 import type { Time } from "./types";
-import { parseMessageDefinition, type RosMsgDefinition, type NamedRosMsgDefinition } from "./parseMessageDefinition";
+import { type RosMsgDefinition, type NamedRosMsgDefinition } from "./parseMessageDefinition";
 
 // write a Time object to a buffer.
 function writeTime(time: Time, buffer: Buffer, offset: number) {
@@ -306,11 +306,10 @@ export class MessageWriter {
   writer: (message: any, bufferToWrite: Buffer) => Buffer;
   bufferSizeCalculator: (message: any) => number;
 
-  // takes a multi-line string message definition and returns
+  // takes an object string message definition and returns
   // a message writer which can be used to write messages based
   // on the message definition
-  constructor(messageDefinition: string) {
-    const definitions = parseMessageDefinition(messageDefinition);
+  constructor(definitions: RosMsgDefinition[]) {
     const { writer, bufferSizeCalculator } = createWriterAndSizeCalculator(definitions);
     this.writer = writer;
     this.bufferSizeCalculator = bufferSizeCalculator;

--- a/src/MessageWriter.js
+++ b/src/MessageWriter.js
@@ -1,0 +1,312 @@
+// Copyright (c) 2018-present, Cruise LLC
+
+// This source code is licensed under the Apache License, Version 2.0,
+// found in the LICENSE file in the root directory of this source tree.
+// You may not use this file except in compliance with the License.
+
+// @flow
+
+import int53 from "int53";
+import type { Time } from "./types";
+import { parseMessageDefinition, type RosMsgDefinition, type NamedRosMsgDefinition } from "./parseMessageDefinition";
+
+// write a Time object to a buffer.
+function writeTime(time: Time, buffer: Buffer, offset: number) {
+  buffer.writeUInt32LE(time.sec, offset);
+  buffer.writeUInt32LE(time.nsec, offset + 4);
+}
+
+class StandardTypeOffsetCalculator {
+  offset = 0;
+
+  // Returns the current offset and increments the next offset by `byteCount`.
+  _incrementAndReturn(byteCount: number) {
+    const offset = this.offset;
+    this.offset += byteCount;
+    return offset;
+  }
+
+  // These are not actually used in the StandardTypeWriter, so they must be kept in sync with those implementations.
+  json(value: any) {
+    return this.string(JSON.stringify(value));
+  }
+
+  // The following are used in the StandardTypeWriter.
+  string(value: string) {
+    // int32 length
+    const length = 4 + value.length;
+    return this._incrementAndReturn(length);
+  }
+
+  bool() {
+    return this.uint8();
+  }
+
+  int8() {
+    return this._incrementAndReturn(1);
+  }
+
+  uint8() {
+    return this._incrementAndReturn(1);
+  }
+
+  int16() {
+    return this._incrementAndReturn(2);
+  }
+
+  uint16() {
+    return this._incrementAndReturn(2);
+  }
+
+  int32() {
+    return this._incrementAndReturn(4);
+  }
+
+  uint32() {
+    return this._incrementAndReturn(4);
+  }
+
+  float32() {
+    return this._incrementAndReturn(4);
+  }
+
+  float64() {
+    return this._incrementAndReturn(8);
+  }
+
+  int64() {
+    return this._incrementAndReturn(8);
+  }
+
+  uint64() {
+    return this._incrementAndReturn(8);
+  }
+
+  time() {
+    return this._incrementAndReturn(8);
+  }
+
+  duration() {
+    return this._incrementAndReturn(8);
+  }
+}
+
+// this has hard-coded buffer writing functions for each
+// of the standard message types http://docs.ros.org/api/std_msgs/html/index-msg.html
+// eventually custom types decompose into these standard types
+class StandardTypeWriter {
+  buffer: Buffer;
+  view: DataView;
+  offsetCalculator: StandardTypeOffsetCalculator;
+
+  constructor(buffer: Buffer) {
+    this.buffer = buffer;
+    this.view = new DataView(buffer.buffer, buffer.byteOffset);
+    this.offsetCalculator = new StandardTypeOffsetCalculator();
+  }
+
+  json(value: any) {
+    this.string(JSON.stringify(value));
+  }
+
+  string(value: string) {
+    const stringOffset = this.offsetCalculator.string(value);
+    this.view.setInt32(stringOffset, value.length, true);
+    this.buffer.write(value, stringOffset + 4, value.length, "ascii");
+  }
+
+  bool(value: bool) {
+    this.uint8(value ? 1 : 0);
+  }
+
+  int8(value: number) {
+    this.view.setInt8(this.offsetCalculator.int8(), value);
+  }
+
+  uint8(value: number) {
+    this.view.setUint8(this.offsetCalculator.uint8(), value);
+  }
+
+  int16(value: number) {
+    this.view.setInt16(this.offsetCalculator.int16(), value, true);
+  }
+
+  uint16(value: number) {
+    this.view.setUint16(this.offsetCalculator.uint16(), value, true);
+  }
+
+  int32(value: number) {
+    this.view.setInt32(this.offsetCalculator.int32(), value, true);
+  }
+
+  uint32(value: number) {
+    this.view.setUint32(this.offsetCalculator.uint32(), value, true);
+  }
+
+  float32(value: number) {
+    this.view.setFloat32(this.offsetCalculator.float32(), value, true);
+  }
+
+  float64(value: number) {
+    this.view.setFloat64(this.offsetCalculator.float64(), value, true);
+  }
+
+  int64(value: number) {
+    int53.writeInt64LE(value, this.buffer, this.offsetCalculator.int64());
+  }
+
+  uint64(value: number) {
+    int53.writeUInt64LE(value, this.buffer, this.offsetCalculator.uint64());
+  }
+
+  time(time: Time) {
+    writeTime(time, this.buffer, this.offsetCalculator.time());
+  }
+
+  duration(time: Time) {
+    writeTime(time, this.buffer, this.offsetCalculator.time());
+  }
+}
+
+const findTypeByName = (types: RosMsgDefinition[], name = ""): NamedRosMsgDefinition => {
+  let foundName = ""; // track name separately in a non-null variable to appease Flow
+  const matches = types.filter((type) => {
+    const typeName = type.name || "";
+    // if the search is empty, return unnamed types
+    if (!name) {
+      return !typeName;
+    }
+    // return if the search is in the type name
+    // or matches exactly if a fully-qualified name match is passed to us
+    const nameEnd = name.indexOf("/") > -1 ? name : `/${name}`;
+    if (typeName.endsWith(nameEnd)) {
+      foundName = typeName;
+      return true;
+    }
+    return false;
+  });
+  if (matches.length !== 1) {
+    throw new Error(`Expected 1 top level type definition for '${name}' but found ${matches.length}`);
+  }
+  return { ...matches[0], name: foundName };
+};
+
+const friendlyName = (name: string) => name.replace("/", "_");
+
+function createWriter(types: RosMsgDefinition[]): (message: any) => Buffer {
+  const unnamedTypes = types.filter((type) => !type.name);
+  if (unnamedTypes.length !== 1) {
+    throw new Error("multiple unnamed types");
+  }
+
+  const [unnamedType] = unnamedTypes;
+
+  const namedTypes: NamedRosMsgDefinition[] = (types.filter((type) => !!type.name): any[]);
+
+  const constructorBody = (type: RosMsgDefinition | NamedRosMsgDefinition, argName: "offsetCalculator" | "writer") => {
+    const writerLines: string[] = [];
+    type.definitions.forEach((def) => {
+      if (def.isConstant) {
+        return;
+      }
+
+      // Accesses the field we are currently writing. Pulled out for easy reuse.
+      const accessMessageField = `message["${def.name}"]`;
+      if (def.isArray) {
+        const lenField = `length_${def.name}`;
+        // set a variable pointing to the parsed fixed array length
+        // or write the byte indicating the dynamic length
+        if (def.arrayLength) {
+          writerLines.push(`var ${lenField} = ${def.arrayLength};`);
+        } else {
+          writerLines.push(`var ${lenField} = ${accessMessageField}.length;`);
+          writerLines.push(`${argName}.uint32(${lenField});`);
+        }
+
+        // start the for-loop
+        writerLines.push(`for (var i = 0; i < ${lenField}; i++) {`);
+        // if the sub type is complex we need to allocate it and parse its values
+        if (def.isComplex) {
+          const defType = findTypeByName(types, def.type);
+          // recursively call the function for the sub-type
+          writerLines.push(`  ${friendlyName(defType.name)}(${argName}, ${accessMessageField}[i]);`);
+        } else {
+          // if the subtype is not complex its a simple low-level operation
+          writerLines.push(`  ${argName}.${def.type}(${accessMessageField}[i]);`);
+        }
+        writerLines.push("}"); // close the for-loop
+      } else if (def.isComplex) {
+        const defType = findTypeByName(types, def.type);
+        writerLines.push(`${friendlyName(defType.name)}(${argName}, ${accessMessageField});`);
+      } else {
+        // Call primitives directly.
+        writerLines.push(`${argName}.${def.type}(${accessMessageField});`);
+      }
+    });
+    return writerLines.join("\n    ");
+  };
+
+  let writerJs = "";
+  let calculateSizeJs = "";
+
+  namedTypes.forEach((t) => {
+    writerJs += `
+  function ${friendlyName(t.name)}(writer, message) {
+    ${constructorBody(t, "writer")}
+  };\n`;
+    calculateSizeJs += `
+  function ${friendlyName(t.name)}(offsetCalculator, message) {
+    ${constructorBody(t, "offsetCalculator")}
+  };\n`;
+  });
+
+  writerJs += `
+  return function write(writer, message) {
+    ${constructorBody(unnamedType, "writer")}
+    return writer.buffer;
+  };`;
+  calculateSizeJs += `
+  return function calculateSize(offsetCalculator, message) {
+    ${constructorBody(unnamedType, "offsetCalculator")}
+    return offsetCalculator.offset;
+  };`;
+
+  let _write: (writer: StandardTypeWriter, message: any) => Buffer;
+  let _calculateSize: (offsetCalculator: StandardTypeOffsetCalculator, message: any) => number;
+  try {
+    _write = eval(`(function buildWriter() { ${writerJs} })()`);
+  } catch (e) {
+    console.error("error building writer:", writerJs); // eslint-disable-line
+    throw e;
+  }
+  try {
+    _calculateSize = eval(`(function buildSizeCalculator() { ${calculateSizeJs} })()`);
+  } catch (e) {
+    console.error("error building size calculator:", calculateSizeJs); // eslint-disable-line
+    throw e;
+  }
+
+  return function(message: any) {
+    const offsetCalculator = new StandardTypeOffsetCalculator();
+    const bufferSize = _calculateSize(offsetCalculator, message);
+    const buffer = new Buffer(bufferSize);
+    const writer = new StandardTypeWriter(buffer);
+    return _write(writer, message);
+  };
+}
+
+export class MessageWriter {
+  writer: (message: any) => Buffer;
+
+  // takes a multi-line string message definition and returns
+  // a message reader which can be used to write messages based
+  // on the message definition
+  constructor(messageDefinition: string) {
+    const definitions = parseMessageDefinition(messageDefinition);
+    this.writer = createWriter(definitions);
+  }
+
+  writeMessage(message: any) {
+    return this.writer(message);
+  }
+}

--- a/src/MessageWriter.js
+++ b/src/MessageWriter.js
@@ -115,7 +115,7 @@ class StandardTypeWriter {
     this.buffer.write(value, stringOffset + 4, value.length, "ascii");
   }
 
-  bool(value: bool) {
+  bool(value: boolean) {
     this.uint8(value ? 1 : 0);
   }
 

--- a/src/MessageWriter.test.js
+++ b/src/MessageWriter.test.js
@@ -24,9 +24,11 @@ describe("MessageWriter", () => {
       cb(buffer);
       it(`writes message ${JSON.stringify(message)} containing ${type}`, () => {
         const writer = new MessageWriter(`${type} foo`);
-        expect(writer.writeMessage({
-          foo: expected,
-        })).toEqual(buffer);
+        expect(
+          writer.writeMessage({
+            foo: expected,
+          })
+        ).toEqual(buffer);
       });
     };
 
@@ -48,9 +50,11 @@ describe("MessageWriter", () => {
     it("writes JSON", () => {
       const writer = new MessageWriter("#pragma rosbag_parse_json\nstring dummy");
       const buff = getStringBuffer('{"foo":123,"bar":{"nestedFoo":456}}');
-      expect(writer.writeMessage({
-        dummy: { foo: 123, bar: { nestedFoo: 456 } },
-      })).toEqual(buff);
+      expect(
+        writer.writeMessage({
+          dummy: { foo: 123, bar: { nestedFoo: 456 } },
+        })
+      ).toEqual(buff);
 
       const writerWithNestedComplexType = new MessageWriter(`#pragma rosbag_parse_json
       string dummy
@@ -81,9 +85,7 @@ describe("MessageWriter", () => {
           dummy: { foo: 123, bar: { nestedFoo: 456 } },
           account: { name: '{"first":"First","last":"Last"}}', id: 100 },
         })
-      ).toEqual(
-        Buffer.concat([buff, getStringBuffer('{"first":"First","last":"Last"}}'), new Buffer([100, 0x00])])
-      );
+      ).toEqual(Buffer.concat([buff, getStringBuffer('{"first":"First","last":"Last"}}'), new Buffer([100, 0x00])]));
     });
 
     it("writes time", () => {
@@ -96,12 +98,14 @@ describe("MessageWriter", () => {
       buff.writeUInt32LE(seconds, 0);
       buff.writeUInt32LE(1000000, 4);
       now.setMilliseconds(1);
-      expect(writer.writeMessage({
-        right_now: {
-          nsec: 1000000,
-          sec: seconds,
-        },
-      })).toEqual(buff);
+      expect(
+        writer.writeMessage({
+          right_now: {
+            nsec: 1000000,
+            sec: seconds,
+          },
+        })
+      ).toEqual(buff);
     });
   });
 
@@ -115,24 +119,32 @@ describe("MessageWriter", () => {
         getStringBuffer("bar"),
         getStringBuffer("baz"),
       ]);
-      expect(writer.writeMessage({
-        names: ["foo", "bar", "baz"],
-      })).toEqual(buffer);
+      expect(
+        writer.writeMessage({
+          names: ["foo", "bar", "baz"],
+        })
+      ).toEqual(buffer);
     });
 
     it("writes fixed length arrays", () => {
       const writer1 = new MessageWriter("string[1] names");
       const writer2 = new MessageWriter("string[2] names");
       const writer3 = new MessageWriter("string[3] names");
-      expect(writer1.writeMessage({
-        names: ["foo", "bar", "baz"],
-      })).toEqual(getStringBuffer("foo"));
-      expect(writer2.writeMessage({
-        names: ["foo", "bar", "baz"],
-      })).toEqual(Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar")]));
-      expect(writer3.writeMessage({
-        names: ["foo", "bar", "baz"],
-      })).toEqual(Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), getStringBuffer("baz")]));
+      expect(
+        writer1.writeMessage({
+          names: ["foo", "bar", "baz"],
+        })
+      ).toEqual(getStringBuffer("foo"));
+      expect(
+        writer2.writeMessage({
+          names: ["foo", "bar", "baz"],
+        })
+      ).toEqual(Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar")]));
+      expect(
+        writer3.writeMessage({
+          names: ["foo", "bar", "baz"],
+        })
+      ).toEqual(Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), getStringBuffer("baz")]));
     });
 
     it("does not write any data for a zero length array", () => {
@@ -349,7 +361,7 @@ describe("MessageWriter", () => {
         status: {
           leve: 0,
           name: "foo",
-        }
+        },
       };
 
       expect(writer.writeMessage(message)).toEqual(buffer);

--- a/src/MessageWriter.test.js
+++ b/src/MessageWriter.test.js
@@ -1,0 +1,413 @@
+// Copyright (c) 2018-present, Cruise LLC
+
+// This source code is licensed under the Apache License, Version 2.0,
+// found in the LICENSE file in the root directory of this source tree.
+// You may not use this file except in compliance with the License.
+
+// @flow
+
+import { MessageReader } from "./MessageReader";
+import { MessageWriter } from "./MessageWriter";
+
+const getStringBuffer = (str: string) => {
+  const data = new Buffer(str, "utf8");
+  const len = new Buffer(4);
+  len.writeInt32LE(data.byteLength, 0);
+  return Buffer.concat([len, data]);
+};
+
+describe("MessageWriter", () => {
+  describe("simple type", () => {
+    const testNum = (type: string, size: number, expected: any, cb: (buffer: Buffer) => any) => {
+      const buffer = new Buffer(size);
+      const message = { foo: expected };
+      cb(buffer);
+      it(`writes message ${JSON.stringify(message)} containing ${type}`, () => {
+        const writer = new MessageWriter(`${type} foo`);
+        expect(writer.writeMessage({
+          foo: expected,
+        })).toEqual(buffer);
+      });
+    };
+
+    testNum("int8", 1, -3, (buffer) => buffer.writeInt8(-3, 0));
+    testNum("uint8", 1, 13, (buffer) => buffer.writeInt8(13, 0));
+    testNum("int16", 2, -21, (buffer) => buffer.writeInt16LE(-21, 0));
+    testNum("uint16", 2, 21, (buffer) => buffer.writeUInt16LE(21, 0));
+    testNum("int32", 4, -210010, (buffer) => buffer.writeInt32LE(-210010, 0));
+    testNum("uint32", 4, 210010, (buffer) => buffer.writeUInt32LE(210010, 0));
+    testNum("float32", 4, 5.5, (buffer) => buffer.writeFloatLE(5.5, 0));
+    testNum("float64", 8, 0xdeadbeefcafebabe, (buffer) => buffer.writeDoubleLE(0xdeadbeefcafebabe, 0));
+
+    it("writes strings", () => {
+      const writer = new MessageWriter("string name");
+      const buff = getStringBuffer("test");
+      expect(writer.writeMessage({ name: "test" })).toEqual(buff);
+    });
+
+    it("writes JSON", () => {
+      const writer = new MessageWriter("#pragma rosbag_parse_json\nstring dummy");
+      const buff = getStringBuffer('{"foo":123,"bar":{"nestedFoo":456}}');
+      expect(writer.writeMessage({
+        dummy: { foo: 123, bar: { nestedFoo: 456 } },
+      })).toEqual(buff);
+
+      const writerWithNestedComplexType = new MessageWriter(`#pragma rosbag_parse_json
+      string dummy
+      Account account
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      `);
+      expect(
+        writerWithNestedComplexType.writeMessage({
+          dummy: { foo: 123, bar: { nestedFoo: 456 } },
+          account: { name: '{"first":"First","last":"Last"}}', id: 100 },
+        })
+      ).toEqual(Buffer.concat([buff, getStringBuffer('{"first":"First","last":"Last"}}'), new Buffer([100, 0x00])]));
+
+      const writerWithTrailingPragmaComment = new MessageWriter(`#pragma rosbag_parse_json
+      string dummy
+      Account account
+      #pragma rosbag_parse_json
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      `);
+      expect(
+        writerWithTrailingPragmaComment.writeMessage({
+          dummy: { foo: 123, bar: { nestedFoo: 456 } },
+          account: { name: '{"first":"First","last":"Last"}}', id: 100 },
+        })
+      ).toEqual(
+        Buffer.concat([buff, getStringBuffer('{"first":"First","last":"Last"}}'), new Buffer([100, 0x00])])
+      );
+    });
+
+    it("writes time", () => {
+      const writer = new MessageWriter("time right_now");
+      const buff = new Buffer(8);
+      const now = new Date();
+      now.setSeconds(31);
+      now.setMilliseconds(0);
+      const seconds = Math.round(now.getTime() / 1000);
+      buff.writeUInt32LE(seconds, 0);
+      buff.writeUInt32LE(1000000, 4);
+      now.setMilliseconds(1);
+      expect(writer.writeMessage({
+        right_now: {
+          nsec: 1000000,
+          sec: seconds,
+        },
+      })).toEqual(buff);
+    });
+  });
+
+  describe("array", () => {
+    it("writes variable length string array", () => {
+      const writer = new MessageWriter("string[] names");
+      const buffer = Buffer.concat([
+        // variable length array has int32 as first entry
+        new Buffer([0x03, 0x00, 0x00, 0x00]),
+        getStringBuffer("foo"),
+        getStringBuffer("bar"),
+        getStringBuffer("baz"),
+      ]);
+      expect(writer.writeMessage({
+        names: ["foo", "bar", "baz"],
+      })).toEqual(buffer);
+    });
+
+    it("writes fixed length arrays", () => {
+      const writer1 = new MessageWriter("string[1] names");
+      const writer2 = new MessageWriter("string[2] names");
+      const writer3 = new MessageWriter("string[3] names");
+      expect(writer1.writeMessage({
+        names: ["foo", "bar", "baz"],
+      })).toEqual(getStringBuffer("foo"));
+      expect(writer2.writeMessage({
+        names: ["foo", "bar", "baz"],
+      })).toEqual(Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar")]));
+      expect(writer3.writeMessage({
+        names: ["foo", "bar", "baz"],
+      })).toEqual(Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), getStringBuffer("baz")]));
+    });
+
+    it("does not write any data for a zero length array", () => {
+      const writer = new MessageWriter("string[] names");
+      const buffer = Buffer.concat([
+        // variable length array has int32 as first entry
+        new Buffer([0x00, 0x00, 0x00, 0x00]),
+      ]);
+
+      const resultBuffer = writer.writeMessage({ names: [] });
+      expect(resultBuffer).toEqual(buffer);
+    });
+
+    describe("typed arrays", () => {
+      it("writes a uint8[]", () => {
+        const writer = new MessageWriter("uint8[] values\nuint8 after");
+        const message = { values: Uint8Array.from([1, 2, 3]), after: 4 };
+        const result = writer.writeMessage(message);
+        const buffer = Buffer.from([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]);
+        expect(result).toEqual(buffer);
+      });
+
+      it("writes a uint8[] with a fixed length", () => {
+        const writer = new MessageWriter("uint8[3] values\nuint8 after");
+        const message = { values: Uint8Array.from([1, 2, 3]), after: 4 };
+        const result = writer.writeMessage(message);
+        const buffer = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+        expect(result).toEqual(buffer);
+      });
+    });
+  });
+
+  describe("complex types", () => {
+    it("writes single complex type", () => {
+      const writer = new MessageWriter("string firstName \n string lastName\nuint16 age");
+      const buffer = Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), new Buffer([0x05, 0x00])]);
+      const message = {
+        firstName: "foo",
+        lastName: "bar",
+        age: 5,
+      };
+      expect(writer.writeMessage(message)).toEqual(buffer);
+    });
+
+    it("writes nested complex types", () => {
+      const messageDefinition = `
+      string username
+      Account account
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      `;
+      const writer = new MessageWriter(messageDefinition);
+      const buffer = Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), new Buffer([100, 0x00])]);
+      const message = {
+        username: "foo",
+        account: {
+          name: "bar",
+          id: 100,
+        },
+      };
+      expect(writer.writeMessage(message)).toEqual(buffer);
+    });
+
+    it("writes nested complex types with arrays", () => {
+      const messageDefinition = `
+      string username
+      Account[] accounts
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      `;
+      const writer = new MessageWriter(messageDefinition);
+      const buffer = Buffer.concat([
+        getStringBuffer("foo"),
+        // uint32LE length of array (2)
+        new Buffer([0x02, 0x00, 0x00, 0x00]),
+        getStringBuffer("bar"),
+        new Buffer([100, 0x00]),
+        getStringBuffer("baz"),
+        new Buffer([101, 0x00]),
+      ]);
+      const message = {
+        username: "foo",
+        accounts: [
+          {
+            name: "bar",
+            id: 100,
+          },
+          {
+            name: "baz",
+            id: 101,
+          },
+        ],
+      };
+      expect(writer.writeMessage(message)).toEqual(buffer);
+    });
+
+    it("writes complex type with nested arrays", () => {
+      const messageDefinition = `
+      string username
+      Account[] accounts
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      Photo[] photos
+
+      =======
+      MSG: custom_type/Photo
+      string url
+      uint8 id
+      `;
+
+      const writer = new MessageWriter(messageDefinition);
+      const buffer = Buffer.concat([
+        getStringBuffer("foo"),
+        // uint32LE length of Account array (2)
+        new Buffer([0x02, 0x00, 0x00, 0x00]),
+        // name
+        getStringBuffer("bar"),
+        // id
+        new Buffer([100, 0x00]),
+        // uint32LE length of Photo array (3)
+        new Buffer([0x03, 0x00, 0x00, 0x00]),
+        // photo url
+        getStringBuffer("http://foo.com"),
+        // photo id
+        new Buffer([10]),
+
+        // photo url
+        getStringBuffer("http://bar.com"),
+        // photo id
+        new Buffer([12]),
+
+        // photo url
+        getStringBuffer("http://zug.com"),
+        // photo id
+        new Buffer([16]),
+
+        // next account
+        getStringBuffer("baz"),
+        new Buffer([101, 0x00]),
+        // uint32LE length of Photo array (0)
+        new Buffer([0x00, 0x00, 0x00, 0x00]),
+      ]);
+
+      const message = {
+        username: "foo",
+        accounts: [
+          {
+            name: "bar",
+            id: 100,
+            photos: [
+              {
+                url: "http://foo.com",
+                id: 10,
+              },
+              {
+                url: "http://bar.com",
+                id: 12,
+              },
+              {
+                url: "http://zug.com",
+                id: 16,
+              },
+            ],
+          },
+          {
+            name: "baz",
+            id: 101,
+            photos: [],
+          },
+        ],
+      };
+
+      expect(writer.writeMessage(message)).toEqual(buffer);
+    });
+
+    const withBytesAndBools = `
+      byte OK=0
+      byte WARN=1
+      byte ERROR=2
+      byte STALE=3
+      byte FOO = 3 # the space exists in some topics
+      byte FLOAT64      = 8
+
+      bool level\t\t# level of operation enumerated above
+
+      DiagnosticStatus status
+
+      ================================================================================
+      MSG: diagnostic_msgs/DiagnosticStatus
+      # This message holds the status of an individual component of the robot.
+      #
+
+      # Possible levels of operations
+      byte OK=0
+      byte WARN=1  # Comment        # FLOATING OUT HERE
+      byte ERROR=2
+      byte STALE=3
+
+      byte    level # level of operation enumerated above
+      string name # a description of the test/component reporting`;
+
+    it("writes bytes and constants", () => {
+      const writer = new MessageWriter(withBytesAndBools);
+      const buffer = Buffer.concat([Buffer.from([0x01]), Buffer.from([0x00]), getStringBuffer("foo")]);
+
+      const message = {
+        level: true,
+        status: {
+          leve: 0,
+          name: "foo",
+        }
+      };
+
+      expect(writer.writeMessage(message)).toEqual(buffer);
+    });
+  });
+
+  describe("MessageReader and MessageWriter outputs are compatible", () => {
+    it("with a complex type", () => {
+      const messageDefinition = `
+      string username
+      Account[] accounts
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      bool isActive
+      Photo[] photos
+
+      =======
+      MSG: custom_type/Photo
+      string url
+      uint8[] ids
+      `;
+
+      const message = {
+        username: "foo",
+        accounts: [
+          {
+            name: "bar",
+            id: 100,
+            isActive: true,
+            photos: [
+              {
+                url: "http://foo.com",
+                ids: Uint8Array.from([10, 100]),
+              },
+              {
+                url: "http://bar.com",
+                ids: Uint8Array.from([12]),
+              },
+              {
+                url: "http://zug.com",
+                ids: Uint8Array.from([]),
+              },
+            ],
+          },
+          {
+            name: "baz",
+            id: 101,
+            isActive: false,
+            photos: [],
+          },
+        ],
+      };
+
+      const reader = new MessageReader(messageDefinition);
+      const writer = new MessageWriter(messageDefinition);
+      expect(reader.readMessage(writer.writeMessage(message))).toEqual(message);
+    });
+  });
+});

--- a/src/MessageWriter.test.js
+++ b/src/MessageWriter.test.js
@@ -368,6 +368,59 @@ describe("MessageWriter", () => {
     });
   });
 
+  describe("calculateBufferSize", () => {
+    it("with a complex type", () => {
+      const messageDefinition = `
+      string username
+      Account[] accounts
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      bool isActive
+      Photo[] photos
+
+      =======
+      MSG: custom_type/Photo
+      string url
+      uint8[] ids
+      `;
+      const message = {
+        username: "foo",
+        accounts: [
+          {
+            name: "bar",
+            id: 100,
+            isActive: true,
+            photos: [
+              {
+                url: "http://foo.com",
+                ids: Uint8Array.from([10, 100]),
+              },
+              {
+                url: "http://bar.com",
+                ids: Uint8Array.from([12]),
+              },
+              {
+                url: "http://zug.com",
+                ids: Uint8Array.from([]),
+              },
+            ],
+          },
+          {
+            name: "baz",
+            id: 101,
+            isActive: false,
+            photos: [],
+          },
+        ],
+      };
+
+      const writer = new MessageWriter(messageDefinition);
+      expect(writer.calculateBufferSize(message)).toEqual(108);
+    });
+  });
+
   describe("MessageReader and MessageWriter outputs are compatible", () => {
     it("with a complex type", () => {
       const messageDefinition = `

--- a/src/bag.js
+++ b/src/bag.js
@@ -12,6 +12,7 @@ import ReadResult from "./ReadResult";
 import { BagHeader, ChunkInfo, Connection, MessageData } from "./record";
 import type { Time } from "./types";
 import * as TimeUtil from "./TimeUtil";
+import { parseMessageDefinition } from "./parseMessageDefinition";
 
 export type ReadOptions = {|
   decompress?: Decompress,
@@ -104,7 +105,8 @@ export default class Bag {
       if (!opts.noParse) {
         // lazily create a reader for this connection if it doesn't exist
         connection.reader =
-          connection.reader || new MessageReader(connection.messageDefinition, { freeze: opts.freeze });
+          connection.reader ||
+          new MessageReader(parseMessageDefinition(connection.messageDefinition), { freeze: opts.freeze });
         message = connection.reader.readMessage(data);
       }
       return new ReadResult(topic, message, timestamp, data, chunkOffset, chunkInfos.length, opts.freeze);

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import * as TimeUtil from "./TimeUtil";
 export * from "./bag";
 export * from "./BagReader";
 export * from "./MessageReader";
+export * from "./MessageWriter";
 export * from "./parseMessageDefinition";
 export * from "./types";
 export * from "./fields";


### PR DESCRIPTION
Add a message writer API that allows writing a message from a JS
object to ROS binary. This does not currently allow bag writing, and
I don't currently have plans to build or use that feature, so this
is mostly standalone for writing individual messages. It is mostly
translated from the existing MessageReader class.

Before writing the message we need to know the binary length of the
message, so we can create the buffer with that size. This currently
requires traversing the message twice, which is likely not very
efficient. I'm going to start with this approach and measure how
performant I need to make this before making further improvements.

Test plan: included all relevant tests from the MessageReader, just
converted to test writing instead.