### PR TITLE
Fix crash bug on deprecated input type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -276,7 +276,7 @@ export class MessageReader {
       );
       parsedDefinitions = parseMessageDefinition(parsedDefinitions);
     }
-    this.reader = createParser(definitions, !!options.freeze);
+    this.reader = createParser(parsedDefinitions, !!options.freeze);
   }
 
   readMessage(buffer: Buffer) {

--- a/src/MessageReader.test.js
+++ b/src/MessageReader.test.js
@@ -143,6 +143,13 @@ describe("MessageReader", () => {
     });
   });
 
+  it("still works given string message definitions", () => {
+    const messageDefinition = "string value";
+    const reader = new MessageReader(parseMessageDefinition(messageDefinition));
+    const buffer = getStringBuffer("foo");
+    expect(reader.readMessage(buffer)).toEqual({ value: "foo" });
+  });
+
   describe("array", () => {
     it("parses variable length string array", () => {
       const reader = new MessageReader(parseMessageDefinition("string[] names"));


### PR DESCRIPTION
Presumably not caught by flow because we didn't want to put the
string alternative in the method signature.

Test plan: added a unit test.