### PR TITLE
Export MessageWriter

### DIFF
--- a/src/MessageWriter.js
+++ b/src/MessageWriter.js
@@ -325,7 +325,7 @@ export class MessageWriter {
     let buffer = bufferToWrite;
     if (!buffer) {
       const bufferSize = this.calculateBufferSize(message);
-      buffer = new Buffer(bufferSize);
+      buffer = Buffer.allocUnsafe(bufferSize);
     }
     return this.writer(message, buffer);
   }

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -10,6 +10,7 @@ import { Buffer } from "buffer";
 import * as fs from "fs";
 import {
   MessageReader,
+  MessageWriter,
   parseMessageDefinition,
   rosPrimitiveTypes,
   TimeUtil,
@@ -98,6 +99,7 @@ export {
   TimeUtil,
   BagReader,
   MessageReader,
+  MessageWriter,
   open,
   parseMessageDefinition,
   rosPrimitiveTypes,

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -9,6 +9,7 @@
 import { Buffer } from "buffer";
 import {
   MessageReader,
+  MessageWriter,
   parseMessageDefinition,
   rosPrimitiveTypes,
   TimeUtil,
@@ -73,6 +74,7 @@ export {
   TimeUtil,
   BagReader,
   MessageReader,
+  MessageWriter,
   open,
   parseMessageDefinition,
   rosPrimitiveTypes,


### PR DESCRIPTION
In this PR I'm adding MessageWriter to the exported entities so we can use it in external projects.
In addition, I'm using `Buffer.allocUnsafe` instead of `new Buffer` as suggested by @MatthewSteel to prevent warnings.

Testing: all existing tests must pass