### PR TITLE
Export message definition types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -8,7 +8,8 @@
 
 import int53 from "int53";
 import { extractTime } from "./fields";
-import { parseMessageDefinition, type RosMsgDefinition, type NamedRosMsgDefinition } from "./parseMessageDefinition";
+import type { RosMsgDefinition, NamedRosMsgDefinition } from "./types";
+import { parseMessageDefinition } from "./parseMessageDefinition";
 
 type TypedArrayConstructor = (
   buffer: ArrayBuffer,

--- a/src/MessageWriter.js
+++ b/src/MessageWriter.js
@@ -7,8 +7,7 @@
 // @flow
 
 import int53 from "int53";
-import type { Time } from "./types";
-import { type RosMsgDefinition, type NamedRosMsgDefinition } from "./parseMessageDefinition";
+import type { Time, RosMsgDefinition, NamedRosMsgDefinition } from "./types";
 
 // write a Time object to a buffer.
 function writeTime(time: Time, buffer: Buffer, offset: number) {

--- a/src/parseMessageDefinition.js
+++ b/src/parseMessageDefinition.js
@@ -6,6 +6,8 @@
 
 // @flow
 
+import type { RosMsgField, RosMsgDefinition } from "./types";
+
 // Set of built-in ros types. See http://wiki.ros.org/msg#Field_Types
 export const rosPrimitiveTypes: Set<string> = new Set([
   "string",
@@ -58,35 +60,6 @@ function newDefinition(type: string, name: string): RosMsgField {
     isComplex: !rosPrimitiveTypes.has(normalizedType),
   };
 }
-
-export type RosMsgField =
-  | {|
-      type: string,
-      name: string,
-      isConstant?: boolean,
-      isComplex?: boolean,
-      value?: mixed,
-      isArray?: false,
-      arrayLength?: void,
-    |}
-  | {|
-      type: string,
-      name: string,
-      isConstant?: boolean,
-      isComplex?: boolean,
-      value?: mixed,
-      isArray: true,
-      arrayLength: ?number,
-    |};
-
-export type RosMsgDefinition = {|
-  name?: string,
-  definitions: RosMsgField[],
-|};
-export type NamedRosMsgDefinition = {|
-  name: string,
-  definitions: RosMsgField[],
-|};
 
 const buildType = (lines: { isJson: boolean, line: string }[]): RosMsgDefinition => {
   const definitions: RosMsgField[] = [];

--- a/src/types.js
+++ b/src/types.js
@@ -22,3 +22,32 @@ export interface Filelike {
   read(offset: number, length: number, callback: Callback<Buffer>): void;
   size(): number;
 }
+
+export type RosMsgField =
+  | {|
+      type: string,
+      name: string,
+      isConstant?: boolean,
+      isComplex?: boolean,
+      value?: mixed,
+      isArray?: false,
+      arrayLength?: void,
+    |}
+  | {|
+      type: string,
+      name: string,
+      isConstant?: boolean,
+      isComplex?: boolean,
+      value?: mixed,
+      isArray: true,
+      arrayLength: ?number,
+    |};
+
+export type RosMsgDefinition = {|
+  name?: string,
+  definitions: RosMsgField[],
+|};
+export type NamedRosMsgDefinition = {|
+  name: string,
+  definitions: RosMsgField[],
+|};


### PR DESCRIPTION
These types are used in Webviz and are important now that MessageReader
does not call parseMessageDefinitions directly.