### PR TITLE
Improve RosMsgField typedef

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/src/types.js
+++ b/src/types.js
@@ -23,25 +23,19 @@ export interface Filelike {
   size(): number;
 }
 
-export type RosMsgField =
-  | {|
-      type: string,
-      name: string,
-      isConstant?: boolean,
-      isComplex?: boolean,
-      value?: mixed,
-      isArray?: false,
-      arrayLength?: void,
-    |}
-  | {|
-      type: string,
-      name: string,
-      isConstant?: boolean,
-      isComplex?: boolean,
-      value?: mixed,
-      isArray: true,
-      arrayLength: ?number,
-    |};
+export type RosMsgField = {|
+  type: string,
+  name: string,
+  isComplex?: boolean,
+
+  // For arrays
+  isArray?: boolean,
+  arrayLength?: ?number,
+
+  // For constants
+  isConstant?: boolean,
+  value?: mixed,
+|};
 
 export type RosMsgDefinition = {|
   name?: string,


### PR DESCRIPTION
This union type adds complexity and isn't necessary. Also add the
value, which is parsed for constants but doesn't appear in the
type defintion. This will allow us to match the typedef in Webviz.

Test plan: only flow type change