### PR TITLE
Expose parser in MessageReader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.7.0",
+  "version": "3.0.0",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/src/MessageReader.test.js
+++ b/src/MessageReader.test.js
@@ -504,4 +504,14 @@ describe("MessageReader", () => {
       }).toThrow();
     });
   });
+
+  it("allows generating a reader from passed-in parser code", () => {
+    const messageDefinition = parseMessageDefinition("string name");
+    const reader1 = new MessageReader(messageDefinition);
+    const reader2 = new MessageReader(messageDefinition, { parserCode: reader1.parserCode });
+
+    const buff = getStringBuffer("test");
+    const output = reader2.readMessage(buff);
+    expect(output).toEqual({ name: "test" });
+  });
 });

--- a/src/MessageWriter.test.js
+++ b/src/MessageWriter.test.js
@@ -6,8 +6,8 @@
 
 // @flow
 
-import { MessageReader } from "./MessageReader";
-import { MessageWriter } from "./MessageWriter";
+import { createMessageReader } from "./MessageReader";
+import { createMessageWriter } from "./MessageWriter";
 import { parseMessageDefinition } from "./parseMessageDefinition";
 
 const getStringBuffer = (str: string) => {
@@ -24,7 +24,7 @@ describe("MessageWriter", () => {
       const message = { foo: expected };
       cb(buffer);
       it(`writes message ${JSON.stringify(message)} containing ${type}`, () => {
-        const writer = new MessageWriter(parseMessageDefinition(`${type} foo`));
+        const writer = createMessageWriter(parseMessageDefinition(`${type} foo`));
         expect(
           writer.writeMessage({
             foo: expected,
@@ -43,13 +43,13 @@ describe("MessageWriter", () => {
     testNum("float64", 8, 0xdeadbeefcafebabe, (buffer) => buffer.writeDoubleLE(0xdeadbeefcafebabe, 0));
 
     it("writes strings", () => {
-      const writer = new MessageWriter(parseMessageDefinition("string name"));
+      const writer = createMessageWriter(parseMessageDefinition("string name"));
       const buff = getStringBuffer("test");
       expect(writer.writeMessage({ name: "test" })).toEqual(buff);
     });
 
     it("writes JSON", () => {
-      const writer = new MessageWriter(parseMessageDefinition("#pragma rosbag_parse_json\nstring dummy"));
+      const writer = createMessageWriter(parseMessageDefinition("#pragma rosbag_parse_json\nstring dummy"));
       const buff = getStringBuffer('{"foo":123,"bar":{"nestedFoo":456}}');
       expect(
         writer.writeMessage({
@@ -57,7 +57,7 @@ describe("MessageWriter", () => {
         })
       ).toEqual(buff);
 
-      const writerWithNestedComplexType = new MessageWriter(
+      const writerWithNestedComplexType = createMessageWriter(
         parseMessageDefinition(`#pragma rosbag_parse_json
       string dummy
       Account account
@@ -74,7 +74,7 @@ describe("MessageWriter", () => {
         })
       ).toEqual(Buffer.concat([buff, getStringBuffer('{"first":"First","last":"Last"}}'), new Buffer([100, 0x00])]));
 
-      const writerWithTrailingPragmaComment = new MessageWriter(
+      const writerWithTrailingPragmaComment = createMessageWriter(
         parseMessageDefinition(`#pragma rosbag_parse_json
       string dummy
       Account account
@@ -94,7 +94,7 @@ describe("MessageWriter", () => {
     });
 
     it("writes time", () => {
-      const writer = new MessageWriter(parseMessageDefinition("time right_now"));
+      const writer = createMessageWriter(parseMessageDefinition("time right_now"));
       const buff = new Buffer(8);
       const now = new Date();
       now.setSeconds(31);
@@ -116,7 +116,7 @@ describe("MessageWriter", () => {
 
   describe("array", () => {
     it("writes variable length string array", () => {
-      const writer = new MessageWriter(parseMessageDefinition("string[] names"));
+      const writer = createMessageWriter(parseMessageDefinition("string[] names"));
       const buffer = Buffer.concat([
         // variable length array has int32 as first entry
         new Buffer([0x03, 0x00, 0x00, 0x00]),
@@ -132,9 +132,9 @@ describe("MessageWriter", () => {
     });
 
     it("writes fixed length arrays", () => {
-      const writer1 = new MessageWriter(parseMessageDefinition("string[1] names"));
-      const writer2 = new MessageWriter(parseMessageDefinition("string[2] names"));
-      const writer3 = new MessageWriter(parseMessageDefinition("string[3] names"));
+      const writer1 = createMessageWriter(parseMessageDefinition("string[1] names"));
+      const writer2 = createMessageWriter(parseMessageDefinition("string[2] names"));
+      const writer3 = createMessageWriter(parseMessageDefinition("string[3] names"));
       expect(
         writer1.writeMessage({
           names: ["foo", "bar", "baz"],
@@ -153,7 +153,7 @@ describe("MessageWriter", () => {
     });
 
     it("does not write any data for a zero length array", () => {
-      const writer = new MessageWriter(parseMessageDefinition("string[] names"));
+      const writer = createMessageWriter(parseMessageDefinition("string[] names"));
       const buffer = Buffer.concat([
         // variable length array has int32 as first entry
         new Buffer([0x00, 0x00, 0x00, 0x00]),
@@ -165,7 +165,7 @@ describe("MessageWriter", () => {
 
     describe("typed arrays", () => {
       it("writes a uint8[]", () => {
-        const writer = new MessageWriter(parseMessageDefinition("uint8[] values\nuint8 after"));
+        const writer = createMessageWriter(parseMessageDefinition("uint8[] values\nuint8 after"));
         const message = { values: Uint8Array.from([1, 2, 3]), after: 4 };
         const result = writer.writeMessage(message);
         const buffer = Buffer.from([0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04]);
@@ -173,7 +173,7 @@ describe("MessageWriter", () => {
       });
 
       it("writes a uint8[] with a fixed length", () => {
-        const writer = new MessageWriter(parseMessageDefinition("uint8[3] values\nuint8 after"));
+        const writer = createMessageWriter(parseMessageDefinition("uint8[3] values\nuint8 after"));
         const message = { values: Uint8Array.from([1, 2, 3]), after: 4 };
         const result = writer.writeMessage(message);
         const buffer = Buffer.from([0x01, 0x02, 0x03, 0x04]);
@@ -184,7 +184,7 @@ describe("MessageWriter", () => {
 
   describe("complex types", () => {
     it("writes single complex type", () => {
-      const writer = new MessageWriter(parseMessageDefinition("string firstName \n string lastName\nuint16 age"));
+      const writer = createMessageWriter(parseMessageDefinition("string firstName \n string lastName\nuint16 age"));
       const buffer = Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), new Buffer([0x05, 0x00])]);
       const message = {
         firstName: "foo",
@@ -203,7 +203,7 @@ describe("MessageWriter", () => {
       string name
       uint16 id
       `;
-      const writer = new MessageWriter(parseMessageDefinition(messageDefinition));
+      const writer = createMessageWriter(parseMessageDefinition(messageDefinition));
       const buffer = Buffer.concat([getStringBuffer("foo"), getStringBuffer("bar"), new Buffer([100, 0x00])]);
       const message = {
         username: "foo",
@@ -224,7 +224,7 @@ describe("MessageWriter", () => {
       string name
       uint16 id
       `;
-      const writer = new MessageWriter(parseMessageDefinition(messageDefinition));
+      const writer = createMessageWriter(parseMessageDefinition(messageDefinition));
       const buffer = Buffer.concat([
         getStringBuffer("foo"),
         // uint32LE length of array (2)
@@ -266,7 +266,7 @@ describe("MessageWriter", () => {
       uint8 id
       `;
 
-      const writer = new MessageWriter(parseMessageDefinition(messageDefinition));
+      const writer = createMessageWriter(parseMessageDefinition(messageDefinition));
       const buffer = Buffer.concat([
         getStringBuffer("foo"),
         // uint32LE length of Account array (2)
@@ -358,7 +358,7 @@ describe("MessageWriter", () => {
       string name # a description of the test/component reporting`;
 
     it("writes bytes and constants", () => {
-      const writer = new MessageWriter(parseMessageDefinition(withBytesAndBools));
+      const writer = createMessageWriter(parseMessageDefinition(withBytesAndBools));
       const buffer = Buffer.concat([Buffer.from([0x01]), Buffer.from([0x00]), getStringBuffer("foo")]);
 
       const message = {
@@ -421,7 +421,7 @@ describe("MessageWriter", () => {
         ],
       };
 
-      const writer = new MessageWriter(parseMessageDefinition(messageDefinition));
+      const writer = createMessageWriter(parseMessageDefinition(messageDefinition));
       expect(writer.calculateBufferSize(message)).toEqual(108);
     });
   });
@@ -475,8 +475,8 @@ describe("MessageWriter", () => {
         ],
       };
 
-      const reader = new MessageReader(parseMessageDefinition(messageDefinition));
-      const writer = new MessageWriter(parseMessageDefinition(messageDefinition));
+      const reader = createMessageReader(parseMessageDefinition(messageDefinition));
+      const writer = createMessageWriter(parseMessageDefinition(messageDefinition));
       expect(reader.readMessage(writer.writeMessage(message))).toEqual(message);
     });
   });

--- a/src/bag.js
+++ b/src/bag.js
@@ -7,7 +7,7 @@
 // @flow
 
 import BagReader, { type Decompress } from "./BagReader";
-import { MessageReader } from "./MessageReader";
+import { createMessageReader } from "./MessageReader";
 import ReadResult from "./ReadResult";
 import { BagHeader, ChunkInfo, Connection, MessageData } from "./record";
 import type { Time } from "./types";
@@ -106,7 +106,7 @@ export default class Bag {
         // lazily create a reader for this connection if it doesn't exist
         connection.reader =
           connection.reader ||
-          new MessageReader(parseMessageDefinition(connection.messageDefinition), { freeze: opts.freeze });
+          createMessageReader(parseMessageDefinition(connection.messageDefinition), { freeze: opts.freeze });
         message = connection.reader.readMessage(data);
       }
       return new ReadResult(topic, message, timestamp, data, chunkOffset, chunkInfos.length, opts.freeze);

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -8,15 +8,7 @@
 
 import { Buffer } from "buffer";
 import * as fs from "fs";
-import {
-  MessageReader,
-  MessageWriter,
-  parseMessageDefinition,
-  rosPrimitiveTypes,
-  TimeUtil,
-  extractFields,
-  extractTime,
-} from "../index";
+import { parseMessageDefinition, rosPrimitiveTypes, TimeUtil, extractFields, extractTime } from "../index";
 import type { Callback } from "../types";
 import Bag from "../bag";
 import BagReader from "../BagReader";
@@ -95,15 +87,7 @@ const open = async (filename: File | string) => {
 Bag.open = open;
 
 export * from "../types";
-export {
-  TimeUtil,
-  BagReader,
-  MessageReader,
-  MessageWriter,
-  open,
-  parseMessageDefinition,
-  rosPrimitiveTypes,
-  extractFields,
-  extractTime,
-};
+export * from "../MessageReader";
+export * from "../MessageWriter";
+export { TimeUtil, BagReader, open, parseMessageDefinition, rosPrimitiveTypes, extractFields, extractTime };
 export default Bag;

--- a/src/record.js
+++ b/src/record.js
@@ -9,7 +9,7 @@
 import int53 from "int53";
 
 import { extractFields, extractTime } from "./fields";
-import { MessageReader } from "./MessageReader";
+import { type MessageReader } from "./MessageReader";
 import type { Time } from "./types";
 
 const readUInt64LE = (buffer: Buffer) => {

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -7,15 +7,7 @@
 // @flow
 
 import { Buffer } from "buffer";
-import {
-  MessageReader,
-  MessageWriter,
-  parseMessageDefinition,
-  rosPrimitiveTypes,
-  TimeUtil,
-  extractFields,
-  extractTime,
-} from "../index";
+import { parseMessageDefinition, rosPrimitiveTypes, TimeUtil, extractFields, extractTime } from "../index";
 import { type Callback } from "../types";
 import Bag from "../bag";
 import BagReader from "../BagReader";
@@ -70,15 +62,7 @@ const open = async (file: File | string) => {
 Bag.open = open;
 
 export * from "../types";
-export {
-  TimeUtil,
-  BagReader,
-  MessageReader,
-  MessageWriter,
-  open,
-  parseMessageDefinition,
-  rosPrimitiveTypes,
-  extractFields,
-  extractTime,
-};
+export * from "../MessageReader";
+export * from "../MessageWriter";
+export { TimeUtil, BagReader, open, parseMessageDefinition, rosPrimitiveTypes, extractFields, extractTime };
 export default Bag;


### PR DESCRIPTION
We are exploring caching the generated parser code and message
definitions. Expose the parser in MessageReader and allow building
a MessageReader with the generated message.

Test plan: included test