### PR TITLE
Prevent errors from SharedArrayBuffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/src/MessageReader.js
+++ b/src/MessageReader.js
@@ -81,7 +81,13 @@ class StandardTypeReader {
       this._intializeTextDecoder();
     }
     if (this._decoder) {
-      return this._decoder.decode(codePoints);
+      // TextDecoder does not support Uint8Arrays that are backed by SharedArrayBuffer, so copy the array here.
+      // SharedArrayBuffer support has been added to the spec, but most browsers have not implemented this change.
+      // See spec change: https://github.com/whatwg/encoding/pull/182
+      // Track browser support here: https://github.com/whatwg/encoding/pull/182#issuecomment-539932294
+      const input = codePoints.buffer instanceof global.SharedArrayBuffer ? new Uint8Array(codePoints) : codePoints;
+
+      return this._decoder.decode(input);
     }
 
     // Otherwise, use string concatentation.


### PR DESCRIPTION
Prevent errors when called with a TypedArray backed by a SharedArrayBuffer

As a workaround, we can copy the requested info into another buffer, which should still be faster than manually converting one character at a time.