### PR TITLE
Add support for "ambiguous" type names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "2.6.4",
+  "version": "3.0.0",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {

--- a/src/BagReader.js
+++ b/src/BagReader.js
@@ -293,13 +293,13 @@ export default class BagReader {
   // read an individual record from a buffer
   readRecordFromBuffer<T: Record>(buffer: Buffer, fileOffset: number, cls: Class<T> & { opcode: number }): T {
     const headerLength = buffer.readInt32LE(0);
-    const record = parseHeader(buffer.slice(4, 4 + headerLength), cls);
+    const headerFields = parseHeader(buffer.slice(4, 4 + headerLength), cls);
 
     const dataOffset = 4 + headerLength + 4;
     const dataLength = buffer.readInt32LE(4 + headerLength);
     const data = buffer.slice(dataOffset, dataOffset + dataLength);
 
-    record.parseData(data);
+    const record = new cls(headerFields, data);
 
     record.offset = fileOffset;
     record.dataOffset = record.offset + 4 + headerLength + 4;

--- a/src/bag.js
+++ b/src/bag.js
@@ -99,14 +99,14 @@ export default class Bag {
 
     function parseMsg(msg: MessageData, chunkOffset: number): ReadResult<any> {
       const connection = connections[msg.conn];
-      const { topic } = connection;
+      const { topic, type } = connection;
       const { data, time: timestamp } = msg;
       let message = null;
       if (!opts.noParse) {
         // lazily create a reader for this connection if it doesn't exist
         connection.reader =
           connection.reader ||
-          new MessageReader(parseMessageDefinition(connection.messageDefinition), { freeze: opts.freeze });
+          new MessageReader(parseMessageDefinition(connection.messageDefinition, type), type, { freeze: opts.freeze });
         message = connection.reader.readMessage(data);
       }
       return new ReadResult(topic, message, timestamp, data, chunkOffset, chunkInfos.length, opts.freeze);

--- a/src/header.js
+++ b/src/header.js
@@ -11,7 +11,7 @@ import { Record } from "./record";
 
 // given a buffer parses out the record within the buffer
 // based on the opcode type bit
-export function parseHeader<T: Record>(buffer: Buffer, cls: Class<T> & { opcode: number }): T {
+export function parseHeader<T: Record>(buffer: Buffer, cls: Class<T> & { opcode: number }): { [key: string]: Buffer } {
   const fields = extractFields(buffer);
   if (fields.op === undefined) {
     throw new Error("Header is missing 'op' field.");
@@ -21,5 +21,5 @@ export function parseHeader<T: Record>(buffer: Buffer, cls: Class<T> & { opcode:
     throw new Error(`Expected ${cls.name} (${cls.opcode}) but found ${opcode}`);
   }
 
-  return new cls(fields);
+  return fields;
 }

--- a/src/types.js
+++ b/src/types.js
@@ -38,10 +38,6 @@ export type RosMsgField = {|
 |};
 
 export type RosMsgDefinition = {|
-  name?: string,
-  definitions: RosMsgField[],
-|};
-export type NamedRosMsgDefinition = {|
   name: string,
   definitions: RosMsgField[],
 |};


### PR DESCRIPTION
The algorithm for resolving ROS type names inside message definitions
that don't have a package specified is,
 - If it's a primitive, use the primitive value.
 - If it's the (reserved) type name `Header`, it's `std_msgs/Header`.
 - Otherwise, use the package of the containing message.

(Note _containing_ message, not top-level message.)

This unfortunately necessitates a breaking change in API. Message
definitions can't be unambiguously parsed without knowing the package of
the top-level message. (Definition MD5s are similarly ambiguous.)

This felt like a good time to merge the named/unnamed definition types.

Test plan:
 - Unit tests have been updated to use the new API.
 - Tested against a development version of webviz. Works on a bag I
   checked, and fixes the "ambiguous datatype" issue reported by a user.