### PR TITLE
add support for bigints for int64 and uint64 types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,10 @@
 # 5.0.0
 
-* MessageWriter now accepts bigint in addition to number for int64 and uint64 types
-* MessageReader now always returns bigint instead of number for int64 and uint64 types
+* MessageWriter now accepts `bigint` in addition to `number` for int64 and uint64 types
+* Removed `int53` dependency
+  
+### Breaking Changes
+* MessageReader now always returns `bigint` instead of `number` for int64 and uint64 types
 
 # 4.0.1
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # 4.0.1
 
+* Enable passing BigInts to MessageWriter for int64 and uint64 types
+
+# 4.0.1
+
 * Add explicit exports so that types match code.
 * Export `OpenBag` type.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# 4.0.1
+# 4.1.0
 
 * Enable passing BigInts to MessageWriter for int64 and uint64 types
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
-# 4.1.0
+# 5.0.0
 
-* Enable passing BigInts to MessageWriter for int64 and uint64 types
+* MessageWriter now accepts bigint in addition to number for int64 and uint64 types
+* MessageReader now always returns bigint instead of number for int64 and uint64 types
 
 # 4.0.1
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.1",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
+  "homepage": "https://github.com/cruise-automation/rosbag.js",
   "dependencies": {
     "buffer": "6.0.3",
     "heap": "0.2.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosbag",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "license": "Apache-2.0",
   "repository": "cruise-automation/rosbag.js",
   "homepage": "https://github.com/cruise-automation/rosbag.js",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "repository": "cruise-automation/rosbag.js",
   "dependencies": {
     "buffer": "6.0.3",
-    "heap": "0.2.7",
-    "int53": "1.0.0"
+    "heap": "0.2.7"
   },
   "engines": {
     "node": ">=14.0.0"
@@ -32,7 +31,6 @@
   },
   "devDependencies": {
     "@types/heap": "0.2.31",
-    "@types/int53": "1.0.0",
     "@types/jest": "29.5.1",
     "@types/node": "20.2.3",
     "@typescript-eslint/eslint-plugin": "5.59.7",

--- a/src/BagReader.test.ts
+++ b/src/BagReader.test.ts
@@ -4,13 +4,12 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import int53 from "int53";
 import BagReader from "./BagReader";
 import { BagHeader } from "./record";
 
 function int64Buffer(number: number) {
   const buff = Buffer.alloc(8);
-  int53.writeInt64LE(number, buff, 0);
+  buff.writeBigInt64LE(BigInt(number), 0);
   return buff;
 }
 

--- a/src/MessageReader.test.ts
+++ b/src/MessageReader.test.ts
@@ -49,6 +49,12 @@ describe("MessageReader", () => {
     testNum("uint32", 4, 210010, (buffer) => buffer.writeUInt32LE(210010, 0));
     testNum("float32", 4, 5.5, (buffer) => buffer.writeFloatLE(5.5, 0));
     testNum("float64", 8, 1.7976931348623157e308, (buffer) => buffer.writeDoubleLE(1.7976931348623157e308, 0));
+    testNum("int64", 8, BigInt(Number.MAX_SAFE_INTEGER), (buffer) =>
+      buffer.writeBigInt64LE(BigInt(Number.MAX_SAFE_INTEGER), 0)
+    );
+    testNum("uint64", 8, BigInt(Number.MAX_SAFE_INTEGER), (buffer) =>
+      buffer.writeBigUInt64LE(BigInt(Number.MAX_SAFE_INTEGER), 0)
+    );
 
     it("parses string", () => {
       const reader = getMessageReader("string name");

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -4,7 +4,6 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import int53 from "int53";
 import { extractTime } from "./fields";
 import type { RosMsgDefinition } from "./types";
 import { parseMessageDefinition } from "./parseMessageDefinition";
@@ -158,13 +157,13 @@ class StandardTypeReader {
   int64() {
     const { offset } = this;
     this.offset += 8;
-    return int53.readInt64LE(this.buffer, offset);
+    return this.view.getBigInt64(offset, true);
   }
 
   uint64() {
     const { offset } = this;
     this.offset += 8;
-    return int53.readUInt64LE(this.buffer, offset);
+    return this.view.getBigUint64(offset, true);
   }
 
   time() {

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -472,6 +472,7 @@ describe("MessageWriter", () => {
       const messageDefinition = `
       string username
       Account[] accounts
+      uint64 favoriteNumber
       ============
       MSG: custom_type/Account
       string name
@@ -485,8 +486,11 @@ describe("MessageWriter", () => {
       uint8[] ids
       `;
 
+      const maxUint64 = BigInt(2) ** BigInt(64) - BigInt(1);
+
       const message = {
         username: "foo",
+        favoriteNumber: maxUint64,
         accounts: [
           {
             name: "bar",

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -42,8 +42,14 @@ describe("MessageWriter", () => {
     testNum("uint32", 4, 210010, (buffer) => buffer.writeUInt32LE(210010, 0));
     testNum("float32", 4, 5.5, (buffer) => buffer.writeFloatLE(5.5, 0));
     testNum("float64", 8, 1.7976931348623157e308, (buffer) => buffer.writeDoubleLE(1.7976931348623157e308, 0));
+    testNum("int64", 8, Number.MAX_SAFE_INTEGER, (buffer) =>
+      buffer.writeBigInt64LE(BigInt(Number.MAX_SAFE_INTEGER), 0)
+    );
     testNum("int64", 8, BigInt(Number.MAX_SAFE_INTEGER), (buffer) =>
       buffer.writeBigInt64LE(BigInt(Number.MAX_SAFE_INTEGER), 0)
+    );
+    testNum("uint64", 8, Number.MAX_SAFE_INTEGER, (buffer) =>
+      buffer.writeBigUInt64LE(BigInt(Number.MAX_SAFE_INTEGER), 0)
     );
     testNum("uint64", 8, BigInt(Number.MAX_SAFE_INTEGER), (buffer) =>
       buffer.writeBigUInt64LE(BigInt(Number.MAX_SAFE_INTEGER), 0)

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -4,7 +4,6 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import int53 from "int53";
 import type { Time, RosMsgDefinition } from "./types";
 
 // write a Time object to a buffer.
@@ -148,12 +147,12 @@ class StandardTypeWriter {
     this.view.setFloat64(this.offsetCalculator.float64(), value, true);
   }
 
-  int64(value: number) {
-    int53.writeInt64LE(value, this.buffer, this.offsetCalculator.int64());
+  int64(value: number | bigint) {
+    this.view.setBigInt64(this.offsetCalculator.int64(), BigInt(value), true);
   }
 
-  uint64(value: number) {
-    int53.writeUInt64LE(value, this.buffer, this.offsetCalculator.uint64());
+  uint64(value: number | bigint) {
+    this.view.setBigUint64(this.offsetCalculator.uint64(), BigInt(value), true);
   }
 
   time(time: Time) {

--- a/src/record.ts
+++ b/src/record.ts
@@ -4,12 +4,9 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import int53 from "int53";
 import { extractFields, extractTime } from "./fields";
 import { MessageReader } from "./MessageReader";
 import type { Time } from "./types";
-
-const readUInt64LE = (buffer: Buffer) => int53.readUInt64LE(buffer, 0);
 
 export class RosbagRecord {
   offset: number;
@@ -38,7 +35,7 @@ export class BagHeader extends RosbagRecord {
 
   constructor(offset: number, dataOffset: number, dataLength: number, fields: Record<string, Buffer>, _buffer: Buffer) {
     super(offset, dataOffset, dataLength);
-    this.indexPosition = readUInt64LE(fields.index_pos);
+    this.indexPosition = Number(fields.index_pos.readBigUInt64LE(0));
     this.connectionCount = fields.conn_count.readInt32LE(0);
     this.chunkCount = fields.chunk_count.readInt32LE(0);
   }
@@ -167,7 +164,7 @@ export class ChunkInfo extends RosbagRecord implements ChunkInfoInterface {
   constructor(offset: number, dataOffset: number, dataLength: number, fields: Record<string, Buffer>, buffer: Buffer) {
     super(offset, dataOffset, dataLength);
     this.ver = fields.ver.readUInt32LE(0);
-    this.chunkPosition = readUInt64LE(fields.chunk_pos);
+    this.chunkPosition = Number(fields.chunk_pos.readBigUInt64LE(0));
     this.startTime = extractTime(fields.start_time, 0);
     this.endTime = extractTime(fields.end_time, 0);
     this.count = fields.count.readUInt32LE(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,13 +750,6 @@
   resolved "https://registry.yarnpkg.com/@types/heap/-/heap-0.2.31.tgz#aaae2b2f7a915810fb783b1bbbf1c0748e399ba9"
   integrity sha1-qq4rL3qRWBD7eDsbu/HAdI45m6k=
 
-"@types/int53@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/int53/-/int53-1.0.0.tgz#1279ac906bb2bec486c13353c5b6e8c97201de33"
-  integrity sha1-EnmskGuyvsSGwTNTxbboyXIB3jM=
-  dependencies:
-    "@types/node" "*"
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -2400,11 +2393,6 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
-
-int53@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/int53/-/int53-1.0.0.tgz#65eef2b8e25df0d8d137520f31c47da67c97aaa1"
-  integrity sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==
 
 internal-slot@^1.0.3, internal-slot@^1.0.4, internal-slot@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
### Changes
- MessageWriter now accepts bigint in addition to number for int64 and uint64 types
- MessageReader now always returns bigint instead of number for int64 and uint64 types

See Foxglove implementation:
https://github.com/foxglove/ros-typescript/blob/be679373864ec591d88902b6337f744a98dc61b1/packages/rosmsg-serialization/src/MessageWriter.ts#L184-L190
